### PR TITLE
fix: change attribute when from elevation to depth

### DIFF
--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -223,6 +223,7 @@ def _depth_subset(
             attrs = dataset["elevation"].attrs
             dataset = dataset.reindex(elevation=dataset.elevation[::-1])
             dataset["elevation"] = dataset.elevation * (-1)
+            attrs["positive"] = "down"
             dataset = dataset.rename({"elevation": "depth"})
             dataset.depth.attrs = attrs
         return dataset

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -198,3 +198,9 @@ class TestPythonInterface:
             dataset_id="cmems_obs-oc_atl_bgc-plankton_nrt_l4-gapfree-multi-1km_P1D",
         )
         assert dataset.time.valid_min > "2024-01-01T00:00:00.000000000"
+
+    def test_subset_modify_attr_positive_to_down_for_depth(self):
+        dataset = open_dataset(
+            dataset_id="cmems_mod_arc_phy_anfc_6km_detided_P1D-m"
+        )
+        assert dataset.depth.attrs["positive"] == "down"


### PR DESCRIPTION
fix [MDSOP-119](https://cms-change.atlassian.net/browse/MDSOP-119)

Actual behavior: 

native files: depth values go from 0 to 4000 and contains 'positive': 'down' attribute
ARCO format: elevation goes from -4000 to -0 and contains 'positive': 'up'  attribute
CMT: depth values go from 0 to 4000 but contains 'positive': 'up'  attribute

