### PR TITLE
Created a function to be able to compute the higher bound

### DIFF
--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -367,13 +367,22 @@ def subset(
 
 def longitude_modulus(longitude: float) -> float:
     """
-    Returns the equivalent longitude between -180 and 180
+    Returns the equivalent longitude between -180 and 179.999999999
     """
     # We are using Decimal to avoid issue with rounding
     modulus = float(Decimal(str(longitude + 180)) % 360)
     # Modulus with python return a negative value if the denominator is negative
     # To counteract that, we add 360 if the result is < 0
     modulus = modulus if modulus >= 0 else modulus + 360
+    return modulus - 180
+
+
+def longitude_modulus_open(longitude: float) -> float:
+    """
+    Returns the equivalent longitude between -179.9999999 and 180
+    """
+    modulus = float(Decimal(str(longitude + 180)) % 360)
+    modulus = modulus if modulus > 0 else modulus + 360
     return modulus - 180
 
 
@@ -434,7 +443,7 @@ def check_dataset_subset_bounds(
                     else longitudes.min()
                 ),
                 user_maximum_coordinate_value=(
-                    longitude_modulus(dataset_subset.maximum_longitude)
+                    longitude_modulus_open(dataset_subset.maximum_longitude)
                     if dataset_subset.maximum_longitude is not None
                     else longitudes.max()
                 ),

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -377,13 +377,14 @@ def longitude_modulus(longitude: float) -> float:
     return modulus - 180
 
 
-def longitude_modulus_open(longitude: float) -> float:
+def longitude_modulus_upper_bound(longitude: float) -> float:
     """
     Returns the equivalent longitude between -179.9999999 and 180
     """
-    modulus = float(Decimal(str(longitude + 180)) % 360)
-    modulus = modulus if modulus > 0 else modulus + 360
-    return modulus - 180
+    modulus = longitude_modulus(longitude)
+    if modulus == -180:
+        return 180
+    return modulus
 
 
 def check_dataset_subset_bounds(
@@ -443,7 +444,9 @@ def check_dataset_subset_bounds(
                     else longitudes.min()
                 ),
                 user_maximum_coordinate_value=(
-                    longitude_modulus_open(dataset_subset.maximum_longitude)
+                    longitude_modulus_upper_bound(
+                        dataset_subset.maximum_longitude
+                    )
                     if dataset_subset.maximum_longitude is not None
                     else longitudes.max()
                 ),

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -383,7 +383,7 @@ def longitude_modulus_upper_bound(longitude: float) -> float:
     """
     modulus = longitude_modulus(longitude)
     if modulus == -180:
-        return 180
+        return 180.0
     return modulus
 
 

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -379,7 +379,7 @@ def longitude_modulus(longitude: float) -> float:
 
 def longitude_modulus_upper_bound(longitude: float) -> float:
     """
-    Returns the equivalent longitude between -179.9999999 and 180
+    Returns the equivalent longitude in ]-180, 180]
     """
     modulus = longitude_modulus(longitude)
     if modulus == -180:

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -367,7 +367,7 @@ def subset(
 
 def longitude_modulus(longitude: float) -> float:
     """
-    Returns the equivalent longitude between -180 and 179.999999999
+    Returns the equivalent longitude in [-180, 180[
     """
     # We are using Decimal to avoid issue with rounding
     modulus = float(Decimal(str(longitude + 180)) % 360)

--- a/tests/test_warnings_subset_bounds.py
+++ b/tests/test_warnings_subset_bounds.py
@@ -30,7 +30,7 @@ class TestWarningsSubsetBounds:
 
         assert b"WARNING" in output.stdout
         assert (
-            b"ome or all of your subset selection [-180.0, 180.0]"
+            b"Some or all of your subset selection [-180.0, 180.0]"
             b" for the longitude dimension  exceed the dataset"
             b" coordinates [-179.9791717529297, 179.9791717529297]"
         ) in output.stdout
@@ -47,11 +47,11 @@ class TestWarningsSubsetBounds:
         output2 = subprocess.run(command2, capture_output=True)
 
         assert (
-            b"ome or all of your subset selection [-180.0, 180.0] for the longitude "
+            b"Some or all of your subset selection [-180.0, 180.0] for the longitude "
             b"dimension  exceed the dataset coordinates [-180.0, 179.91668701171875]"
         ) in output1.stdout
         assert (
-            b"ome or all of your subset selection [-179.9, 179.9] for the longitude "
+            b"Some or all of your subset selection [-179.9, 179.9] for the longitude "
             b"dimension  exceed the dataset coordinates [-180.0, 179.91668701171875]"
         ) not in output2.stdout  # Here they don't have to appear
 
@@ -71,12 +71,12 @@ class TestWarningsSubsetBounds:
         output2 = subprocess.run(command2, capture_output=True)
 
         assert (
-            b"ome or all of your subset selection [-180.0, 180.0] for the longitude "
+            b"Some or all of your subset selection [-180.0, 180.0] for the longitude "
             b"dimension  exceed the dataset coordinates "
             b"[-179.9791717529297, 179.9791717529297]"
         ) in output1.stdout
         assert (
-            b"ome or all of your subset selection [-179.99, 179.99] for the longitude "
+            b"Some or all of your subset selection [-179.99, 179.99] for the longitude "
             b"dimension  exceed the dataset coordinates "
             b"[-179.9791717529297, 179.9791717529297]"
         ) in output2.stdout

--- a/tests/test_warnings_subset_bounds.py
+++ b/tests/test_warnings_subset_bounds.py
@@ -1,0 +1,82 @@
+import subprocess
+
+
+class TestWarningsSubsetBounds:
+    def _build_custom_command(
+        self, dataset_id, variable, min_longitude, max_longitude
+    ):
+        return [
+            "copernicusmarine",
+            "subset",
+            "--dataset-id",
+            f"{dataset_id}",
+            "--variable",
+            f"{variable}",
+            "--minimum-longitude",
+            f"{min_longitude}",
+            "--maximum-longitude",
+            f"{max_longitude}",
+        ]
+
+    def test_subset_warning_properly(self):
+        # Dataset with longitude bounds from -179.97... to 179.91...
+        # The call should return a warning (and correctly the bounds)
+        dataset_id = (
+            "cmems_obs-oc_glo_bgc-plankton_nrt_l4-gapfree-multi-4km_P1D"
+        )
+        command = self._build_custom_command(dataset_id, "CHL", -180, 180)
+
+        output = subprocess.run(command, capture_output=True)
+
+        assert b"WARNING" in output.stdout
+        assert (
+            b"ome or all of your subset selection [-180.0, 180.0]"
+            b" for the longitude dimension  exceed the dataset"
+            b" coordinates [-179.9791717529297, 179.9791717529297]"
+        ) in output.stdout
+
+    def test_subset_warnings_differently(self):
+        # Dataset with longitude bounds from -180 to 179.91668701171875
+        # The first call should return a warning, the second one should not
+        dataset_id = "cmems_mod_glo_phy-thetao_anfc_0.083deg_P1D-m"
+
+        command1 = self._build_custom_command(dataset_id, "thetao", -180, 180)
+        command2 = self._build_custom_command(dataset_id, "thetao", -179, 179)
+
+        output1 = subprocess.run(command1, capture_output=True)
+        output2 = subprocess.run(command2, capture_output=True)
+
+        assert (
+            b"ome or all of your subset selection [-180.0, 180.0] for the longitude "
+            b"dimension  exceed the dataset coordinates [-180.0, 179.91668701171875]"
+        ) in output1.stdout
+        assert (
+            b"ome or all of your subset selection [-179.9, 179.9] for the longitude "
+            b"dimension  exceed the dataset coordinates [-180.0, 179.91668701171875]"
+        ) not in output2.stdout  # Here they don't have to appear
+
+    def test_subset_warnings_when_surpassing(self):
+        # Dataset with longitude bounds from [-179.9791717529297, 179.9791717529297]
+        # Both calls should return the same warning
+        dataset_id = (
+            "cmems_obs-oc_glo_bgc-plankton_nrt_l4-gapfree-multi-4km_P1D"
+        )
+
+        command1 = self._build_custom_command(dataset_id, "CHL", -180, 180)
+        command2 = self._build_custom_command(
+            dataset_id, "CHL", -179.99, 179.99
+        )
+
+        output1 = subprocess.run(command1, capture_output=True)
+        output2 = subprocess.run(command2, capture_output=True)
+
+        assert (
+            b"ome or all of your subset selection [-180.0, 180.0] for the longitude "
+            b"dimension  exceed the dataset coordinates "
+            b"[-179.9791717529297, 179.9791717529297]"
+        ) in output1.stdout
+        assert (
+            b"ome or all of your subset selection [-179.99, 179.99] for the longitude "
+            b"dimension  exceed the dataset coordinates "
+            b"[-179.9791717529297, 179.9791717529297]"
+        ) in output2.stdout


### PR DESCRIPTION
Resolving [issue 278](https://mercator-ocean.atlassian.net/browse/CMCS-278).

To do so, I made sure that the interval was returning the correct options, adding a function to be able to compute higher bounds. With the code as is it right now, it raises warning's when the user request is out of bounds.

I would suggest, though, that if the subset is complete (from [-180, 180[) this warning is not raised. This is actually not working this way, because if the user request is [-180,180] is will never get to 180... I think the fix could be useful.