### PR TITLE
fix: change dataset for the tests

### DIFF
--- a/tests/resources/request_files/test_subset_error_when_forced_service_does_not_exist.json
+++ b/tests/resources/request_files/test_subset_error_when_forced_service_does_not_exist.json
@@ -1,5 +1,5 @@
 {
-  "dataset_id": "cmems_mod_arc_bgc_anfc_ecosmo_P1D-m",
+  "dataset_id": "cmems_obs-si_glo_phy-drift-south_my_l4_P1D-m",
   "end_datetime": "2021-01-02",
   "force_download": false,
   "maximum_latitude": 0.1,


### PR DESCRIPTION
The dataset we used for testing when we don't have ARCO services has them now so I changed it
Only test/development specific 