### PR TITLE
Bounding box

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,21 @@ In addition to this option, you can also provide the `--netcdf-compression-level
 #### Note about `--netcdf3-compatible` option
 The `--netcdf3-compatible` option has been added to allow the downloaded dataset to be compatible with the netCDF3 format. It uses the `format="NETCDF3_CLASSIC"` of the xarray [to_netcdf](https://docs.xarray.dev/en/latest/generated/xarray.Dataset.to_netcdf.html) method.
 
+#### Note about the `--bounding-box-method` option
+The `--bounding-box-method` option has been added to allow for different funcitonalities with the requested area. The default method `inside` returns all data points that are included within the requested area. The available option `outside` returns all data points such that all the area requested is returned.
+
+For example, when requesting for **longitude** values in the range (0.01, 2.98) for the two different cases:
+
+>* --bounding-box-method **inside**
+>
+>Returned dataset longitude: [0.08334, 2.917]
+>
+>* --bounding-box-method **outside**
+>
+>Returned dataset longitude: [0.0, 3.0]
+
+
+
 ### Command `get`
 Download the dataset file(s) as originally produced, based on the datasetID or the path to files.
 

--- a/copernicusmarine/catalogue_parser/catalogue_parser.py
+++ b/copernicusmarine/catalogue_parser/catalogue_parser.py
@@ -138,8 +138,7 @@ def _service_type_from_web_api_string(
     )
 
 
-class ServiceNotHandled(Exception):
-    ...
+class ServiceNotHandled(Exception): ...
 
 
 VERSION_DEFAULT = "default"
@@ -240,12 +239,10 @@ class CopernicusMarineDatasetVersion:
         return self.parts[0].released_date, self.parts[0].retired_date
 
 
-class DatasetVersionPartNotFound(Exception):
-    ...
+class DatasetVersionPartNotFound(Exception): ...
 
 
-class DatasetVersionNotFound(Exception):
-    ...
+class DatasetVersionNotFound(Exception): ...
 
 
 @dataclass
@@ -360,8 +357,7 @@ class ProductDatasetParser(ABC):
     @abstractmethod
     def to_copernicus_marine_dataset(
         self,
-    ) -> CopernicusMarineProductDataset:
-        ...
+    ) -> CopernicusMarineProductDataset: ...
 
 
 @dataclass

--- a/copernicusmarine/catalogue_parser/request_structure.py
+++ b/copernicusmarine/catalogue_parser/request_structure.py
@@ -11,8 +11,10 @@ from copernicusmarine.core_functions.deprecated_options import (
     DEPRECATED_OPTIONS,
 )
 from copernicusmarine.core_functions.models import (
+    DEFAULT_BOUNDING_BOX_METHOD,
     DEFAULT_FILE_FORMAT,
     DEFAULT_SUBSET_METHOD,
+    BoundingBoxMethod,
     FileFormat,
     SubsetMethod,
 )
@@ -59,6 +61,7 @@ class SubsetRequest:
     vertical_dimension_as_originally_produced: bool = True
     start_datetime: Optional[datetime] = None
     end_datetime: Optional[datetime] = None
+    bounding_box: BoundingBoxMethod = DEFAULT_BOUNDING_BOX_METHOD
     subset_method: SubsetMethod = DEFAULT_SUBSET_METHOD
     output_filename: Optional[str] = None
     file_format: FileFormat = DEFAULT_FILE_FORMAT
@@ -290,6 +293,7 @@ class LoadRequest:
         default_factory=TemporalParameters
     )
     depth_parameters: DepthParameters = field(default_factory=DepthParameters)
+    bounding_box: BoundingBoxMethod = DEFAULT_BOUNDING_BOX_METHOD
     subset_method: SubsetMethod = DEFAULT_SUBSET_METHOD
     force_service: Optional[str] = None
     credentials_file: Optional[pathlib.Path] = None

--- a/copernicusmarine/command_line_interface/group_subset.py
+++ b/copernicusmarine/command_line_interface/group_subset.py
@@ -20,10 +20,15 @@ from copernicusmarine.core_functions.deprecated import (
     DeprecatedClickOptionsCommand,
 )
 from copernicusmarine.core_functions.models import (
+    DEFAULT_BOUNDING_BOX_METHOD,
+    DEFAULT_BOUNDING_BOX_METHODS,
+    DEFAULT_BOUNDING_BOX_METHOD,
+    DEFAULT_BOUNDING_BOX_METHODS,
     DEFAULT_FILE_FORMAT,
     DEFAULT_FILE_FORMATS,
     DEFAULT_SUBSET_METHOD,
     DEFAULT_SUBSET_METHODS,
+    BoundingBoxMethod,
     FileFormat,
     SubsetMethod,
 )
@@ -207,6 +212,17 @@ def cli_group_subset() -> None:
     + 'with " " to ensure valid expression for format "%Y-%m-%d %H:%M:%S".',
 )
 @click.option(
+    "--bounding-box-method",
+    type=click.Choice(DEFAULT_BOUNDING_BOX_METHODS),
+    default=DEFAULT_BOUNDING_BOX_METHOD,
+    help=(
+        "The bounding box method when requesting the dataset. If inside, "
+        "(by default) it will return all points interior to the area. "
+        "If outside, it will return all the data such that the box is  "
+        "fully included. Check the documentation for more details."
+    ),
+)
+@click.option(
     "--subset-method",
     type=click.Choice(DEFAULT_SUBSET_METHODS),
     default=DEFAULT_SUBSET_METHOD,
@@ -376,6 +392,7 @@ def subset(
     vertical_dimension_as_originally_produced: bool,
     start_datetime: Optional[datetime],
     end_datetime: Optional[datetime],
+    bounding_box_method: BoundingBoxMethod,
     subset_method: SubsetMethod,
     output_filename: Optional[str],
     file_format: FileFormat,
@@ -429,6 +446,7 @@ def subset(
         vertical_dimension_as_originally_produced,
         start_datetime,
         end_datetime,
+        bounding_box_method,
         subset_method,
         output_filename,
         file_format,

--- a/copernicusmarine/core_functions/models.py
+++ b/copernicusmarine/core_functions/models.py
@@ -11,3 +11,7 @@ DEFAULT_FILE_EXTENSIONS = list(get_args(FileExtension))
 SubsetMethod = Literal["nearest", "strict"]
 DEFAULT_SUBSET_METHOD: SubsetMethod = "nearest"
 DEFAULT_SUBSET_METHODS = list(get_args(SubsetMethod))
+
+BoundingBoxMethod = Literal["inside", "outside"]
+DEFAULT_BOUNDING_BOX_METHOD: BoundingBoxMethod = "inside"
+DEFAULT_BOUNDING_BOX_METHODS = list(get_args(BoundingBoxMethod))

--- a/copernicusmarine/core_functions/services_utils.py
+++ b/copernicusmarine/core_functions/services_utils.py
@@ -457,13 +457,15 @@ def _get_retrieval_service_from_dataset_version(
             f'one was selected: "{dataset_part.name}"'
         )
     if dataset_part.retired_date:
+
         _warning_dataset_will_be_deprecated(
             dataset_id, dataset_version, dataset_part
         )
     if dataset_part.released_date and datetime_parser(
         dataset_part.released_date
     ) > datetime_parser("now"):
-        _warning_dataset_not_yet_released(
+
+        _warning_dataset_will_be_deprecated(
             dataset_id, dataset_version, dataset_part
         )
 

--- a/copernicusmarine/core_functions/subset.py
+++ b/copernicusmarine/core_functions/subset.py
@@ -17,7 +17,10 @@ from copernicusmarine.catalogue_parser.request_structure import (
 from copernicusmarine.core_functions.credentials_utils import (
     get_and_check_username_password,
 )
-from copernicusmarine.core_functions.models import SubsetMethod
+from copernicusmarine.core_functions.models import (
+    BoundingBoxMethod,
+    SubsetMethod,
+)
 from copernicusmarine.core_functions.services_utils import (
     CommandType,
     RetrievalService,
@@ -59,6 +62,7 @@ def subset_function(
     vertical_dimension_as_originally_produced: bool,
     start_datetime: Optional[datetime],
     end_datetime: Optional[datetime],
+    bounding_box: BoundingBoxMethod,
     subset_method: SubsetMethod,
     output_filename: Optional[str],
     file_format: FileFormat,
@@ -122,6 +126,7 @@ def subset_function(
         "vertical_dimension_as_originally_produced": vertical_dimension_as_originally_produced,  # noqa
         "start_datetime": start_datetime,
         "end_datetime": end_datetime,
+        "bounding_box": bounding_box,
         "subset_method": subset_method,
         "output_filename": output_filename,
         "file_format": file_format,

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -8,6 +8,7 @@ import xarray
 
 from copernicusmarine.catalogue_parser.request_structure import SubsetRequest
 from copernicusmarine.core_functions import sessions
+from copernicusmarine.core_functions.models import BoundingBoxMethod
 from copernicusmarine.core_functions.utils import (
     FORCE_DOWNLOAD_CLI_PROMPT_MESSAGE,
     add_copernicusmarine_version_in_dataset_attributes,
@@ -66,6 +67,7 @@ def download_dataset(
     geographical_parameters: GeographicalParameters,
     temporal_parameters: TemporalParameters,
     depth_parameters: DepthParameters,
+    bounding_box: BoundingBoxMethod,
     dataset_url: str,
     output_directory: pathlib.Path,
     output_filename: Optional[str],
@@ -87,6 +89,7 @@ def download_dataset(
             geographical_parameters=geographical_parameters,
             temporal_parameters=temporal_parameters,
             depth_parameters=depth_parameters,
+            bounding_box=bounding_box,
             chunks="auto",
         )
     )
@@ -183,6 +186,7 @@ def download_zarr(
         geographical_parameters=geographical_parameters,
         temporal_parameters=temporal_parameters,
         depth_parameters=depth_parameters,
+        bounding_box=subset_request.bounding_box,
         dataset_url=dataset_url,
         output_directory=output_directory,
         output_filename=subset_request.output_filename,
@@ -206,6 +210,7 @@ def open_dataset_from_arco_series(
     geographical_parameters: GeographicalParameters,
     temporal_parameters: TemporalParameters,
     depth_parameters: DepthParameters,
+    bounding_box: BoundingBoxMethod,
     chunks=Optional[Literal["auto"]],
 ) -> xarray.Dataset:
     dataset = sessions.open_zarr(
@@ -219,6 +224,7 @@ def open_dataset_from_arco_series(
         geographical_parameters=geographical_parameters,
         temporal_parameters=temporal_parameters,
         depth_parameters=depth_parameters,
+        bounding_box=bounding_box,
     )
     return dataset
 
@@ -231,6 +237,7 @@ def read_dataframe_from_arco_series(
     geographical_parameters: GeographicalParameters,
     temporal_parameters: TemporalParameters,
     depth_parameters: DepthParameters,
+    bounding_box: BoundingBoxMethod,
     chunks: Optional[Literal["auto"]],
 ) -> pandas.DataFrame:
     dataset = open_dataset_from_arco_series(
@@ -241,6 +248,7 @@ def read_dataframe_from_arco_series(
         geographical_parameters=geographical_parameters,
         temporal_parameters=temporal_parameters,
         depth_parameters=depth_parameters,
+        bounding_box=bounding_box,
         chunks=chunks,
     )
     return dataset.to_dataframe()

--- a/copernicusmarine/python_interface/load_utils.py
+++ b/copernicusmarine/python_interface/load_utils.py
@@ -89,6 +89,7 @@ def load_data_object_from_load_request(
             geographical_parameters=load_request.geographical_parameters,
             temporal_parameters=load_request.temporal_parameters,
             depth_parameters=load_request.depth_parameters,
+            bounding_box=load_request.bounding_box,
             chunks=None,
         )
     else:

--- a/copernicusmarine/python_interface/open_dataset.py
+++ b/copernicusmarine/python_interface/open_dataset.py
@@ -13,7 +13,9 @@ from copernicusmarine.core_functions.deprecated_options import (
     DEPRECATED_OPTIONS,
 )
 from copernicusmarine.core_functions.models import (
+    DEFAULT_BOUNDING_BOX_METHOD,
     DEFAULT_SUBSET_METHOD,
+    BoundingBoxMethod,
     SubsetMethod,
 )
 from copernicusmarine.download_functions.download_arco_series import (
@@ -63,6 +65,7 @@ def open_dataset(
     vertical_dimension_as_originally_produced: bool = True,
     start_datetime: Optional[Union[datetime, str]] = None,
     end_datetime: Optional[Union[datetime, str]] = None,
+    bounding_box: BoundingBoxMethod = DEFAULT_BOUNDING_BOX_METHOD,
     subset_method: SubsetMethod = DEFAULT_SUBSET_METHOD,
     service: Optional[str] = None,
     credentials_file: Optional[Union[pathlib.Path, str]] = None,
@@ -92,6 +95,7 @@ def open_dataset(
         vertical_dimension_as_originally_produced (bool, optional): If True, use the vertical dimension as originally produced.
         start_datetime (datetime, optional): The start datetime for temporal subsetting.
         end_datetime (datetime, optional): The end datetime for temporal subsetting.
+        bounding_box (BoundingBoxMethod, optional): Method for bounding box.
         service (str, optional): Force the use of a specific service (ARCO geo series or time series).
         credentials_file (Union[pathlib.Path, str], optional): Path to a file containing authentication credentials.
         overwrite_metadata_cache (bool, optional): If True, overwrite the metadata cache.
@@ -132,6 +136,7 @@ def open_dataset(
             maximum_depth=maximum_depth,
             vertical_dimension_as_originally_produced=vertical_dimension_as_originally_produced,  # noqa
         ),
+        bounding_box=bounding_box,
         subset_method=subset_method,
         force_service=service,
         credentials_file=credentials_file,

--- a/copernicusmarine/python_interface/read_dataframe.py
+++ b/copernicusmarine/python_interface/read_dataframe.py
@@ -13,7 +13,9 @@ from copernicusmarine.core_functions.deprecated_options import (
     DEPRECATED_OPTIONS,
 )
 from copernicusmarine.core_functions.models import (
+    DEFAULT_BOUNDING_BOX_METHOD,
     DEFAULT_SUBSET_METHOD,
+    BoundingBoxMethod,
     SubsetMethod,
 )
 from copernicusmarine.download_functions.download_arco_series import (
@@ -63,6 +65,7 @@ def read_dataframe(
     vertical_dimension_as_originally_produced: bool = True,
     start_datetime: Optional[Union[datetime, str]] = None,
     end_datetime: Optional[Union[datetime, str]] = None,
+    bounding_box: BoundingBoxMethod = DEFAULT_BOUNDING_BOX_METHOD,
     subset_method: SubsetMethod = DEFAULT_SUBSET_METHOD,
     force_service: Optional[str] = None,
     credentials_file: Optional[Union[pathlib.Path, str]] = None,
@@ -91,6 +94,7 @@ def read_dataframe(
         vertical_dimension_as_originally_produced (bool, optional): If True, use the vertical dimension as originally produced.
         start_datetime (datetime, optional): Start datetime for temporal subset.
         end_datetime (datetime, optional): End datetime for temporal subset.
+        bounding_box (BoundingBoxMethod, optional): Method for bounding box.
         force_service (str, optional): Force a specific service for data download.
         credentials_file (Union[pathlib.Path, str], optional): Path to a credentials file for authentication.
         overwrite_metadata_cache (bool, optional): If True, overwrite the metadata cache.
@@ -132,6 +136,7 @@ def read_dataframe(
             maximum_depth=maximum_depth,
             vertical_dimension_as_originally_produced=vertical_dimension_as_originally_produced,  # noqa
         ),
+        bounding_box=bounding_box,
         force_service=force_service,
         credentials_file=credentials_file,
         overwrite_metadata_cache=overwrite_metadata_cache,

--- a/copernicusmarine/python_interface/subset.py
+++ b/copernicusmarine/python_interface/subset.py
@@ -7,8 +7,10 @@ from copernicusmarine.core_functions.deprecated_options import (
     DEPRECATED_OPTIONS,
 )
 from copernicusmarine.core_functions.models import (
+    DEFAULT_BOUNDING_BOX_METHOD,
     DEFAULT_FILE_FORMAT,
     DEFAULT_SUBSET_METHOD,
+    BoundingBoxMethod,
     FileFormat,
     SubsetMethod,
 )
@@ -38,6 +40,7 @@ def subset(
     vertical_dimension_as_originally_produced: bool = True,
     start_datetime: Optional[Union[datetime, str]] = None,
     end_datetime: Optional[Union[datetime, str]] = None,
+    bounding_box: BoundingBoxMethod = DEFAULT_BOUNDING_BOX_METHOD,
     subset_method: SubsetMethod = DEFAULT_SUBSET_METHOD,
     output_filename: Optional[str] = None,
     file_format: FileFormat = DEFAULT_FILE_FORMAT,
@@ -76,6 +79,7 @@ def subset(
         vertical_dimension_as_originally_produced (bool, optional): Use original vertical dimension.
         start_datetime (datetime, optional): Start datetime for temporal subset.
         end_datetime (datetime, optional): End datetime for temporal subset.
+        bounding_box (str, optional): The bounding box method ('inside' or 'outside') when requesting the dataset.
         subset_method (str, optional): The subset method ('nearest' or 'strict') when requesting the dataset. If strict, you can only request dimension strictly inside the dataset.
         output_filename (str, optional): Output filename for the subsetted data.
         file_format (str, optional): Extension format for the filename.
@@ -122,6 +126,7 @@ def subset(
         vertical_dimension_as_originally_produced,
         start_datetime,
         end_datetime,
+        bounding_box,
         subset_method,
         output_filename,
         file_format,

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -1,12 +1,12 @@
 import inspect
 import os
+import subprocess
 from datetime import datetime, timedelta
 from pathlib import Path
 
 import xarray
 
 from copernicusmarine import (
-    core_functions,
     describe,
     get,
     login,
@@ -14,6 +14,10 @@ from copernicusmarine import (
     read_dataframe,
     subset,
 )
+from copernicusmarine.core_functions.exceptions import (
+    CoordinatesOutOfDatasetBounds,
+)
+from tests.test_utils import execute_in_terminal
 
 
 class TestPythonInterface:
@@ -264,5 +268,95 @@ class TestPythonInterface:
                 end_datetime=datetime.today()
                 + timedelta(days=10, hours=23, minutes=59),
             )
-        except core_functions.exceptions.CoordinatesOutOfDatasetBounds as e:
+        except CoordinatesOutOfDatasetBounds as e:
             assert "Some or all of your subset selection" in e.__str__()
+
+    def test_bounding_box_method(self, tmp_path):
+        output_filename = "output.nc"
+        min_longitude = 0.01
+        max_longitude = 2.97
+        min_latitude = 0.01
+        max_latitude = 3.1
+        start_datetime = "2020-11-01T01:00:00"
+        end_datetime = "2021-12-12T01:00:00"
+        command = [
+            "copernicusmarine",
+            "subset",
+            "--dataset-id",
+            "cmems_mod_glo_phy-thetao_anfc_0.083deg_P1D-m",
+            "--variable",
+            "thetao",
+            "--minimum-longitude",
+            f"{min_longitude}",
+            "--maximum-longitude",
+            f"{max_longitude}",
+            "--minimum-latitude",
+            f"{min_latitude}",
+            "--maximum-latitude",
+            f"{max_latitude}",
+            "--start-datetime",
+            f"{start_datetime}",
+            "--end-datetime",
+            f"{end_datetime}",
+            "--bounding-box-method",
+            "outside",
+            "-o",
+            f"{tmp_path}",
+            "-f",
+            f"{output_filename}",
+            "--force-download",
+        ]
+        output = subprocess.run(command)
+
+        dataset = xarray.open_dataset(Path(tmp_path, output_filename))
+        assert output.returncode == 0
+        assert dataset.longitude.values.min() <= min_longitude
+        assert dataset.longitude.values.max() >= max_longitude
+        assert dataset.latitude.values.min() <= min_latitude
+        assert dataset.latitude.values.max() >= max_latitude
+        assert datetime.strptime(
+            str(dataset.time.values.min()), "%Y-%m-%dT%H:%M:%S.000%f"
+        ) <= datetime.strptime(start_datetime, "%Y-%m-%dT%H:%M:%S")
+        assert datetime.strptime(
+            str(dataset.time.values.max()), "%Y-%m-%dT%H:%M:%S.000%f"
+        ) >= datetime.strptime(end_datetime, "%Y-%m-%dT%H:%M:%S")
+
+    def test_bounding_box_method_outside_dataset_bounds(self, tmp_path):
+        output_filename = "output.nc"
+        min_longitude = 179.0
+        max_longitude = 181.0
+        min_latitude = 0.01
+        max_latitude = 3.1
+        start_datetime = "2024-01-01T01:00:00"
+        end_datetime = "2024-05-12T01:00:00"
+        command = [
+            "copernicusmarine",
+            "subset",
+            "--dataset-id",
+            "cmems_obs-oc_glo_bgc-plankton_nrt_l4-gapfree-multi-4km_P1D",
+            "--variable",
+            "CHL",
+            "--minimum-longitude",
+            f"{min_longitude}",
+            "--maximum-longitude",
+            f"{max_longitude}",
+            "--minimum-latitude",
+            f"{min_latitude}",
+            "--maximum-latitude",
+            f"{max_latitude}",
+            "--start-datetime",
+            f"{start_datetime}",
+            "--end-datetime",
+            f"{end_datetime}",
+            "--bounding-box-method",
+            "outside",
+            "-o",
+            f"{tmp_path}",
+            "-f",
+            f"{output_filename}",
+            "--force-download",
+        ]
+        output = execute_in_terminal(command)
+
+        assert b"ERROR" in output.stdout
+        assert output.returncode == 1


### PR DESCRIPTION
Link to error [CMCS - 244](https://mercator-ocean.atlassian.net/browse/CMCS-244). 

I created a new flag `'bounding-box-method'` for more advanced users to be able to ask for a region that encompasses their requested area. It would have two options, `'inside'` (by default) or `'outside'`.

This is not yet implemented in Xarray (see third row of code [here](https://docs.xarray.dev/en/latest/user-guide/indexing.html#nearest-neighbor-lookups)) so the implementation looks up manually the limiting points (I will add the part of the code where it does this down below).

I still need to add the latitude (time too? it is also asked in the ticket) to the methodology but I thought that making the pull request would be useful to discuss the implementation.

Also I think it would be best to add some tests to it, right?
