### PR TITLE
default _Fillvalue attribute

### DIFF
--- a/copernicusmarine/download_functions/common_download.py
+++ b/copernicusmarine/download_functions/common_download.py
@@ -58,19 +58,22 @@ def _prepare_download_dataset_as_netcdf(
 ):
     logger.debug("Writing dataset to NetCDF")
     encoding: dict[str, Any]
+    encoding = {f"{coord}": {"_FillValue": None} for coord in dataset.coords}
     if netcdf_compression_enabled:
         complevel = (
             1 if netcdf_compression_level is None else netcdf_compression_level
         )
         logger.info(f"NetCDF compression enabled with level {complevel}")
         comp = dict(
-            zlib=True, complevel=complevel, contiguous=False, shuffle=True
+            zlib=True,
+            complevel=complevel,
+            contiguous=False,
+            shuffle=True,
+            _FillValue=None,
         )
-        encoding = {var: comp for var in dataset.data_vars}
-    else:
-        encoding = {
-            f"{coord}": {"_FillValue": None} for coord in dataset.coords
-        }
+        encoding_vars = {var: comp for var in dataset.data_vars}
+        encoding.update(encoding_vars)
+
     xarray_download_format = "NETCDF3_CLASSIC" if netcdf3_compatible else None
     return dataset.to_netcdf(
         output_path,

--- a/copernicusmarine/download_functions/common_download.py
+++ b/copernicusmarine/download_functions/common_download.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from typing import Optional
+from typing import Any, Optional
 
 import xarray
 import zarr
@@ -57,6 +57,7 @@ def _prepare_download_dataset_as_netcdf(
     netcdf3_compatible: bool,
 ):
     logger.debug("Writing dataset to NetCDF")
+    encoding: dict[str, Any]
     if netcdf_compression_enabled:
         complevel = (
             1 if netcdf_compression_level is None else netcdf_compression_level
@@ -67,7 +68,10 @@ def _prepare_download_dataset_as_netcdf(
         )
         encoding = {var: comp for var in dataset.data_vars}
     else:
-        encoding = None
+        encoding = {
+            f"{coord}": {"_FillValue": None} for coord in dataset.coords
+        }
+        logger.info(encoding)
     xarray_download_format = "NETCDF3_CLASSIC" if netcdf3_compatible else None
     return dataset.to_netcdf(
         output_path,

--- a/copernicusmarine/download_functions/common_download.py
+++ b/copernicusmarine/download_functions/common_download.py
@@ -71,7 +71,6 @@ def _prepare_download_dataset_as_netcdf(
         encoding = {
             f"{coord}": {"_FillValue": None} for coord in dataset.coords
         }
-        logger.info(encoding)
     xarray_download_format = "NETCDF3_CLASSIC" if netcdf3_compatible else None
     return dataset.to_netcdf(
         output_path,

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -3,6 +3,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 
+import xarray
+
 from copernicusmarine import (
     describe,
     get,
@@ -206,3 +208,25 @@ class TestPythonInterface:
         assert dataset.depth.attrs["positive"] == "down"
         assert dataset.depth.attrs["standard_name"] == "depth"
         assert dataset.depth.attrs["long_name"] == "Depth"
+
+    def test_subset_keeps_fillvalue_empty(self):
+        subset(
+            dataset_id="cmems_mod_glo_phy-thetao_anfc_0.083deg_P1D-m",
+            dataset_version="202211",
+            variables=["thetao"],
+            minimum_longitude=-28.10,
+            maximum_longitude=-27.94,
+            minimum_latitude=40.20,
+            maximum_latitude=40.44,
+            start_datetime="2024-02-23T00:00:00",
+            end_datetime="2024-02-23T23:59:59",
+            minimum_depth=0,
+            maximum_depth=1,
+            force_download=True,
+            output_filename="netcdf_fillval.nc",
+        )
+
+        subsetdata = xarray.open_dataset("netcdf_fillval.nc", decode_cf=False)
+        print(f"longitude attrs: {subsetdata.longitude.attrs}")
+        assert "_FillValue" not in subsetdata.longitude.attrs
+        assert "valid_max" in subsetdata.longitude.attrs


### PR DESCRIPTION
Fixing the default _FillValue attribute reported in error [CMCS-361](https://mercator-ocean.atlassian.net/browse/CMCS-361).

Inspired in the solution proposed in the same ticket and in [this stack-overflow issue](https://stackoverflow.com/questions/45693688/xarray-automatically-applying-fillvalue-to-coordinates-on-netcdf-output/45696423#45696423).

When downloading the data, before passing it to the NetCDF file, the encoding is applied. 

Hope the definition of the dictionary is good enough with the type-written format.