### PR TITLE
fix: wrong units in encoding

### DIFF
--- a/copernicusmarine/download_functions/common_download.py
+++ b/copernicusmarine/download_functions/common_download.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from typing import Any, Optional
+from typing import Optional
 
 import xarray
 import zarr
@@ -57,8 +57,10 @@ def _prepare_download_dataset_as_netcdf(
     netcdf3_compatible: bool,
 ):
     logger.debug("Writing dataset to NetCDF")
-    encoding: dict[str, Any]
-    encoding = {f"{coord}": {"_FillValue": None} for coord in dataset.coords}
+    for coord in dataset.coords:
+        if "_FillValue" in dataset[coord].encoding:
+            dataset[coord].encoding["_FillValue"] = None
+
     if netcdf_compression_enabled:
         complevel = (
             1 if netcdf_compression_level is None else netcdf_compression_level
@@ -69,10 +71,10 @@ def _prepare_download_dataset_as_netcdf(
             complevel=complevel,
             contiguous=False,
             shuffle=True,
-            _FillValue=None,
         )
-        encoding_vars = {var: comp for var in dataset.data_vars}
-        encoding.update(encoding_vars)
+        encoding = {var: comp for var in dataset.data_vars}
+    else:
+        encoding = None
 
     xarray_download_format = "NETCDF3_CLASSIC" if netcdf3_compatible else None
     return dataset.to_netcdf(

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -227,7 +227,6 @@ class TestPythonInterface:
             output_filename="netcdf_fillval.nc",
         )
         subsetdata = xarray.open_dataset("netcdf_fillval.nc", decode_cf=False)
-        print(subsetdata.time.attrs)
         assert "_FillValue" not in subsetdata.longitude.attrs
         assert "_FillValue" not in subsetdata.time.attrs
         assert "_FillValue" not in subsetdata.latitude.attrs

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -226,10 +226,14 @@ class TestPythonInterface:
             force_download=True,
             output_filename="netcdf_fillval.nc",
         )
-
         subsetdata = xarray.open_dataset("netcdf_fillval.nc", decode_cf=False)
+        print(subsetdata.time.attrs)
         assert "_FillValue" not in subsetdata.longitude.attrs
+        assert "_FillValue" not in subsetdata.time.attrs
+        assert "_FillValue" not in subsetdata.latitude.attrs
         assert "valid_max" in subsetdata.longitude.attrs
+        assert subsetdata.time.attrs["calendar"] == "gregorian"
+        assert subsetdata.time.attrs["units"] == "hours since 1950-01-01"
 
     def test_subset_keeps_fillvalue_empty_w_compression(self):
         subset(
@@ -253,7 +257,11 @@ class TestPythonInterface:
             "netcdf_fillval_compressed.nc", decode_cf=False
         )
         assert "_FillValue" not in subsetdata.longitude.attrs
+        assert "_FillValue" not in subsetdata.time.attrs
+        assert "_FillValue" not in subsetdata.latitude.attrs
         assert "valid_max" in subsetdata.longitude.attrs
+        assert subsetdata.time.attrs["calendar"] == "gregorian"
+        assert subsetdata.time.attrs["units"] == "hours since 1950-01-01"
 
     def test_error_Coord_out_of_dataset_bounds(self):
         try:


### PR DESCRIPTION
Fixing bug [CMT-6](https://cms-change.atlassian.net/browse/CMT-6).

Wrong units when encoding to netcdf.

When setting `encoding={'time': {'_FillValue': None}}` XArray is losing the information for the rest, like the units or the calendar.