### PR TITLE
fix: change astype int to use datetime

### DIFF
--- a/copernicusmarine/core_functions/utils.py
+++ b/copernicusmarine/core_functions/utils.py
@@ -150,7 +150,7 @@ def convert_datetime64_to_netcdf_timestamp(
 ) -> int:
     nanosecond = 1e-9
     date = datetime.fromtimestamp(
-        datetime_value.astype(int) * nanosecond, tz=timezone.utc
+        datetime_value.astype(datetime) * nanosecond, tz=timezone.utc
     )
     return cftime.date2num(date, cftime_unit)
 

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -65,11 +65,6 @@ def _dataset_custom_sel(
                 nearest_neighbor_value = dataset.sel(
                     {coord_label: target}, method="nearest"
                 )[coord_label].values
-                if coord_label == "time":
-                    nanosecond = 1e-9
-                    nearest_neighbor_value = datetime.fromtimestamp(
-                        nearest_neighbor_value.astype(datetime) * nanosecond
-                    )
                 dataset = dataset.sel(
                     {
                         coord_label: slice(

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -68,7 +68,7 @@ def _dataset_custom_sel(
                 if coord_label == "time":
                     nanosecond = 1e-9
                     nearest_neighbor_value = datetime.fromtimestamp(
-                        nearest_neighbor_value.astype(int) * nanosecond
+                        nearest_neighbor_value.astype(datetime) * nanosecond
                     )
                 dataset = dataset.sel(
                     {


### PR DESCRIPTION
Seems like `astype(int)` from `numpy.datetime64` is returning completely different results on Windows than on Unix creating two bugs
https://cms-change.atlassian.net/browse/CMT-9
and https://cms-change.atlassian.net/browse/CMT-8