### PR TITLE
chore: deleting logger.warn

### DIFF
--- a/copernicusmarine/core_functions/services_utils.py
+++ b/copernicusmarine/core_functions/services_utils.py
@@ -535,7 +535,7 @@ def _warning_dataset_will_be_deprecated(
     dataset_version: CopernicusMarineDatasetVersion,
     dataset_part: CopernicusMarineVersionPart,
 ):
-    logger.warn(
+    logger.warning(
         f"""The dataset {dataset_id}"""
         f"""{f", version '{dataset_version.label}'"
              if dataset_version.label != 'default' else ''}"""
@@ -552,7 +552,7 @@ def _warning_dataset_not_yet_released(
     dataset_version: CopernicusMarineDatasetVersion,
     dataset_part: CopernicusMarineVersionPart,
 ):
-    logger.warn(
+    logger.warning(
         f"""The dataset {dataset_id}"""
         f"""{f", version '{dataset_version.label}'"
              if dataset_version.label != 'default' else ''}"""


### PR DESCRIPTION
Trying to solve deprecation warnings, raised in [CMT-5](https://cms-change.atlassian.net/browse/CMT-5) reported in [Issue in dfm-tools](https://github.com/Deltares/dfm_tools/issues/803).

We will need to process a little bit better the aiohttp.ClientSession() but this solves the first and easiest error.