### PR TITLE
fix: windows doesnt accept timestamp before 1970

### DIFF
--- a/copernicusmarine/core_functions/utils.py
+++ b/copernicusmarine/core_functions/utils.py
@@ -3,7 +3,7 @@ import logging
 import os
 import pathlib
 import re
-from datetime import datetime, timezone
+from datetime import datetime
 from importlib.metadata import version
 from typing import (
     Any,
@@ -21,6 +21,7 @@ from typing import (
 
 import cftime
 import numpy
+import pandas as pd
 import xarray
 from requests import PreparedRequest
 
@@ -148,11 +149,8 @@ def convert_datetime64_to_netcdf_timestamp(
     datetime_value: numpy.datetime64,
     cftime_unit: str,
 ) -> int:
-    nanosecond = 1e-9
-    date = datetime.fromtimestamp(
-        datetime_value.astype(datetime) * nanosecond, tz=timezone.utc
-    )
-    return cftime.date2num(date, cftime_unit)
+    pandas_datetime = pd.to_datetime(datetime_value)
+    return cftime.date2num(pandas_datetime, cftime_unit)
 
 
 def add_copernicusmarine_version_in_dataset_attributes(

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -1332,7 +1332,7 @@ class TestCommandLineInterface:
             "--dataset-url",
             "https://s3.waw3-1.cloudferro.com/mdl-native-14/native/"
             "GLOBAL_ANALYSISFORECAST_PHY_001_024/"
-            "cmems_mod_glo_phy_anfc_0.083deg_P1D-m_202211/2023/11",
+            "cmems_mod_glo_phy_anfc_0.083deg_P1D-m_202406/2023/11",
         ]
 
         self.output = execute_in_terminal(command)

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -213,7 +213,6 @@ class TestPythonInterface:
     def test_subset_keeps_fillvalue_empty(self, tmp_path):
         subset(
             dataset_id="cmems_mod_glo_phy-thetao_anfc_0.083deg_P1D-m",
-            dataset_version="202211",
             variables=["thetao"],
             minimum_longitude=-28.10,
             maximum_longitude=-27.94,
@@ -243,7 +242,6 @@ class TestPythonInterface:
     def test_subset_keeps_fillvalue_empty_w_compression(self, tmp_path):
         subset(
             dataset_id="cmems_mod_glo_phy-thetao_anfc_0.083deg_P1D-m",
-            dataset_version="202211",
             variables=["thetao"],
             minimum_longitude=-28.10,
             maximum_longitude=-27.94,


### PR DESCRIPTION
fix [CMT-85]( https://cms-change.atlassian.net/browse/CMT-85)

Interestingly it seems like Windows does not support date before 1970. Hence the bug described in CMT-85 where the open dataset tries to set a valid min in 1950