### PR TITLE
Deleting valid_min and valid_max attributes

### DIFF
--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -21,10 +21,7 @@ from copernicusmarine.core_functions.exceptions import (
     VariableDoesNotExistInTheDataset,
 )
 from copernicusmarine.core_functions.models import SubsetMethod
-from copernicusmarine.core_functions.utils import (
-    ServiceNotSupported,
-    convert_datetime64_to_netcdf_timestamp,
-)
+from copernicusmarine.core_functions.utils import ServiceNotSupported
 from copernicusmarine.download_functions.subset_parameters import (
     DepthParameters,
     GeographicalParameters,
@@ -47,8 +44,6 @@ NETCDF_CONVENTION_VARIABLE_ATTRIBUTES = [
     "long_name",
     "units",
     "unit_long",
-    "valid_min",
-    "valid_max",
 ]
 NETCDF_CONVENTION_COORDINATE_ATTRIBUTES = [
     "standard_name",
@@ -359,34 +354,15 @@ def _update_dataset_coordinate_attributes(
                     NETCDF_CONVENTION_COORDINATE_ATTRIBUTES.copy()
                 )
                 if "time" in coordinate_label:
-                    min_time_dimension = coord.values.min()
-                    max_time_dimension = coord.values.max()
-                    netcdf_unit = coord.encoding["units"]
-                    valid_min = convert_datetime64_to_netcdf_timestamp(
-                        min_time_dimension, netcdf_unit
-                    )
-                    valid_max = convert_datetime64_to_netcdf_timestamp(
-                        max_time_dimension, netcdf_unit
-                    )
                     attrs["standard_name"] = "time"
                     attrs["long_name"] = "Time"
-                    attrs["valid_min"] = valid_min
-                    attrs["valid_max"] = valid_max
                     attrs["axis"] = "T"
                     attrs["unit_long"] = (
                         coord.encoding["units"].replace("_", " ").title()
                     )
                     coordinate_attributes.remove("units")
                 elif coordinate_label in ["depth", "elevation"]:
-                    attrs["valid_min"] = coord.values.min()
-                    attrs["valid_max"] = coord.values.max()
                     coordinate_attributes.append("positive")
-                elif coordinate_label == "latitude":
-                    attrs["valid_min"] = coord.values.min()
-                    attrs["valid_max"] = coord.values.max()
-                elif coordinate_label == "longitude":
-                    coordinate_attributes.remove("valid_min")
-                    coordinate_attributes.remove("valid_max")
                 coord.attrs = _filter_attributes(attrs, coordinate_attributes)
 
     dataset.attrs = _filter_attributes(

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -44,6 +44,8 @@ NETCDF_CONVENTION_VARIABLE_ATTRIBUTES = [
     "long_name",
     "units",
     "unit_long",
+    "valid_min",
+    "valid_max",
 ]
 NETCDF_CONVENTION_COORDINATE_ATTRIBUTES = [
     "standard_name",
@@ -51,8 +53,6 @@ NETCDF_CONVENTION_COORDINATE_ATTRIBUTES = [
     "units",
     "unit_long",
     "axis",
-    "valid_min",
-    "valid_max",
 ]
 NETCDF_CONVENTION_DATASET_ATTRIBUTES = [
     "title",

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -494,36 +494,6 @@ class TestCommandLineInterface:
             b"copernicusmarine get --dataset-id " + bytes(dataset_id, "utf-8")
         ) in self.output.stderr
 
-    def test_if_dataset_coordinate_valid_minmax_attributes_are_setted(
-        self, tmp_path
-    ):
-        self.base_request_dict = {
-            "--dataset-id": "cmems_mod_glo_phy-so_anfc_0.083deg_P1D-m",
-            "--variable": "so",
-            "--start-datetime": "2024-01-01",
-            "--end-datetime": "2024-01-02",
-            "--minimum-latitude": "0.0",
-            "--maximum-latitude": "0.1",
-            "--minimum-longitude": "0.2",
-            "--maximum-longitude": "0.3",
-            "--minimum-depth": "0.0",
-            "--maximum-depth": "5.0",
-            "-f": "self.output.nc",
-            "--output-directory": tmp_path,
-        }
-
-        self.check_default_subset_request(self.GEOSERIES.subpath, tmp_path)
-
-        dataset_path = pathlib.Path(tmp_path) / "self.output.nc"
-        dataset = xarray.open_dataset(dataset_path)
-
-        assert dataset.latitude.attrs["valid_min"] >= 0
-        assert dataset.latitude.attrs["valid_max"] <= 0.1
-        assert dataset.depth.attrs["valid_min"] >= 0
-        assert dataset.depth.attrs["valid_max"] <= 5
-        assert dataset.time.attrs["valid_min"] == 648672
-        assert dataset.time.attrs["valid_max"] == 648696
-
     def test_retention_period_works(self):
         self.command = [
             "copernicusmarine",

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -221,7 +221,7 @@ class TestPythonInterface:
             password=os.getenv("COPERNICUSMARINE_SERVICE_PASSWORD"),
             dataset_id="cmems_obs-oc_atl_bgc-plankton_nrt_l4-gapfree-multi-1km_P1D",
         )
-        assert dataset.time.valid_min >= 45388
+        assert int(dataset.time.min().values) >= 1720735200000
 
     def test_subset_modify_attr_for_depth(self):
         dataset = open_dataset(
@@ -256,10 +256,6 @@ class TestPythonInterface:
         assert "_FillValue" not in subsetdata.time.attrs
         assert "_FillValue" not in subsetdata.latitude.attrs
         assert "_FillValue" not in subsetdata.depth.attrs
-        assert "valid_max" not in subsetdata.longitude.attrs
-        assert "valid_min" not in subsetdata.longitude.attrs
-        assert "valid_max" in subsetdata.latitude.attrs
-        assert "valid_max" in subsetdata.latitude.attrs
         assert subsetdata.time.attrs["calendar"] == "gregorian"
         assert subsetdata.time.attrs["units"] == "hours since 1950-01-01"
 


### PR DESCRIPTION
Following the discussion in [CMT-53](https://cms-change.atlassian.net/browse/CMT-53), I deleted the valid_min and valid_max attributes for the dimensions. 

Still needs to be determined if we want to add min or max values as suggested, but it looks like we don't retrieve such values from the metadata...