### PR TITLE
Adapt type of valid minmax

### DIFF
--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -449,7 +449,7 @@ def _update_variables_attributes(
         dataset[variable].attrs = _filter_attributes(
             dataset[variable].attrs, NETCDF_CONVENTION_VARIABLE_ATTRIBUTES
         )
-        if "valid_min" in dataset[variable].attrs:
+        if "valid_min" and "valid_max" in dataset[variable].attrs:
             _adequate_dtypes_of_valid_minmax(dataset, variable)
     return dataset
 

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -449,7 +449,8 @@ def _update_variables_attributes(
         dataset[variable].attrs = _filter_attributes(
             dataset[variable].attrs, NETCDF_CONVENTION_VARIABLE_ATTRIBUTES
         )
-        _adequate_dtypes_of_valid_minmax(dataset, variable)
+        if "valid_min" in dataset[variable].attrs:
+            _adequate_dtypes_of_valid_minmax(dataset, variable)
     return dataset
 
 

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -449,7 +449,10 @@ def _update_variables_attributes(
         dataset[variable].attrs = _filter_attributes(
             dataset[variable].attrs, NETCDF_CONVENTION_VARIABLE_ATTRIBUTES
         )
-        if "valid_min" and "valid_max" in dataset[variable].attrs:
+        if (
+            "valid_min" in dataset[variable].attrs
+            and "valid_max" in dataset[variable].attrs
+        ):
             _adequate_dtypes_of_valid_minmax(dataset, variable)
     return dataset
 

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -430,6 +430,18 @@ def _get_variable_name_from_standard_name(
     return None
 
 
+def _adequate_dtypes_of_valid_minmax(
+    dataset: xarray.Dataset, variable: str
+) -> xarray.Dataset:
+    dataset[variable].attrs["valid_min"] = numpy.array(
+        [dataset[variable].attrs["valid_min"]], dtype=dataset[variable].dtype
+    )[0]
+    dataset[variable].attrs["valid_max"] = numpy.array(
+        [dataset[variable].attrs["valid_max"]], dtype=dataset[variable].dtype
+    )[0]
+    return dataset
+
+
 def _update_variables_attributes(
     dataset: xarray.Dataset, variables: List[str]
 ) -> xarray.Dataset:
@@ -437,6 +449,7 @@ def _update_variables_attributes(
         dataset[variable].attrs = _filter_attributes(
             dataset[variable].attrs, NETCDF_CONVENTION_VARIABLE_ATTRIBUTES
         )
+        _adequate_dtypes_of_valid_minmax(dataset, variable)
     return dataset
 
 


### PR DESCRIPTION
In [Pull 127](https://github.com/mercator-ocean/copernicus-marine-toolbox/pull/127) we discovered that the values of `valid_min` and `valid_max` didn't have the same format as the variable, which isn't consistent with the CF convention.

I've created this changes to make sure that the types of the values are correct.