### PR TITLE
fix: not converting properly timestamp

### DIFF
--- a/copernicusmarine/core_functions/utils.py
+++ b/copernicusmarine/core_functions/utils.py
@@ -145,7 +145,7 @@ def timestamp_parser(
     by default. The unit can be changed to seconds by passing "s" as
     the unit.
     """
-    conversion_factor = 1 if unit == "s" else 10e3
+    conversion_factor = 1 if unit == "s" else 1e3
     return pendulum.from_timestamp(timestamp / conversion_factor, tz="UTC")
 
 

--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -2,7 +2,10 @@ from datetime import datetime, timezone
 
 from freezegun import freeze_time
 
-from copernicusmarine.core_functions.utils import datetime_parser
+from copernicusmarine.core_functions.utils import (
+    datetime_parser,
+    timestamp_parser,
+)
 
 
 class TestUtilityFunctions:
@@ -34,4 +37,18 @@ class TestUtilityFunctions:
         )
         assert datetime_parser("2012-01-14T03:21:34.000000Z") == datetime(
             2012, 1, 14, 3, 21, 34, tzinfo=timezone.utc
+        )
+
+    def test_timestamp_parser(self):
+        assert timestamp_parser(-630633600000) == datetime(
+            1950, 1, 7, 0, 0, 0, tzinfo=timezone.utc
+        )
+        assert timestamp_parser(0) == datetime(
+            1970, 1, 1, 0, 0, 0, tzinfo=timezone.utc
+        )
+        assert timestamp_parser(1672527600000) == datetime(
+            2022, 12, 31, 23, 0, 0, tzinfo=timezone.utc
+        )
+        assert timestamp_parser(1672527600, unit="s") == datetime(
+            2022, 12, 31, 23, 0, 0, tzinfo=timezone.utc
         )


### PR DESCRIPTION
A fix that was found thanks to the tests

This would return the wrong start value: 

```
copernicusmarine subset -i cmems_mod_blk_wav_my_2.5km_PT1H-i --end-datetime 1980-09-10 -v VCMX
```