### PR TITLE
fix: decimal not handled with modulus

### DIFF
--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -552,11 +552,11 @@ def longitude_modulus(longitude: float) -> float:
     Returns the equivalent longitude in [-180, 180[
     """
     # We are using Decimal to avoid issue with rounding
-    modulus = float(Decimal(str(longitude + 180)) % 360)
+    modulus = (Decimal(str(longitude)) + 180) % 360
     # Modulus with python return a negative value if the denominator is negative
     # To counteract that, we add 360 if the result is < 0
     modulus = modulus if modulus >= 0 else modulus + 360
-    return modulus - 180
+    return float(modulus - 180)
 
 
 def longitude_modulus_upper_bound(longitude: float) -> float:


### PR DESCRIPTION
Found a bug with full test datasets where the decimals were not correctly handled

this would fail: 

```
copernicusmarine subset -i cmems_obs_oc_blk_bgc_tur-spm-chl_nrt_l3-hr-mosaic_P1D-m -x 26.000661375661405 -X 26.000661375661405
```