### PR TITLE
chore: update the output when listing files

### DIFF
--- a/copernicusmarine/download_functions/download_original_files.py
+++ b/copernicusmarine/download_functions/download_original_files.py
@@ -467,7 +467,7 @@ def _list_files_on_marine_data_lake_s3(
         Prefix=prefix,
         Delimiter="/" if not recursive else "",
     )
-    logger.info("Listing files on the server...")
+    logger.info("Listing files on remote server...")
     s3_objects = chain(
         *map(lambda page: page.get("Contents", []), tqdm(page_iterator))
     )

--- a/copernicusmarine/download_functions/download_original_files.py
+++ b/copernicusmarine/download_functions/download_original_files.py
@@ -457,7 +457,6 @@ def _list_files_on_marine_data_lake_s3(
     prefix: str,
     recursive: bool,
 ) -> list[tuple[str, int, DateTime, str]]:
-
     s3_client, _ = get_configured_boto3_session(
         endpoint_url, ["ListObjects"], username
     )
@@ -468,11 +467,10 @@ def _list_files_on_marine_data_lake_s3(
         Prefix=prefix,
         Delimiter="/" if not recursive else "",
     )
-
+    logger.info("Listing files on the server...")
     s3_objects = chain(
-        *map(lambda page: page.get("Contents", []), page_iterator)
+        *map(lambda page: page.get("Contents", []), tqdm(page_iterator))
     )
-
     files_already_found: list[tuple[str, int, DateTime, str]] = []
     for s3_object in s3_objects:
         files_already_found.append(

--- a/copernicusmarine/download_functions/download_original_files.py
+++ b/copernicusmarine/download_functions/download_original_files.py
@@ -81,6 +81,7 @@ def download_original_files(
             get_request.sync,
             create_file_list,
             pathlib.Path(get_request.output_directory),
+            disable_progress_bar,
             only_list_root_path=get_request.index_parts,
             overwrite=get_request.overwrite_output_data,
         )
@@ -254,6 +255,7 @@ def _download_header(
     sync: bool,
     create_file_list: Optional[str],
     directory_out: pathlib.Path,
+    disable_progress_bar: bool,
     only_list_root_path: bool = False,
     overwrite: bool = False,
 ) -> Optional[
@@ -276,7 +278,12 @@ def _download_header(
     last_modified_datetimes: list[DateTime] = []
     etags: list[str] = []
     raw_filenames = _list_files_on_marine_data_lake_s3(
-        username, endpoint_url, bucket, path, not only_list_root_path
+        username,
+        endpoint_url,
+        bucket,
+        path,
+        not only_list_root_path,
+        disable_progress_bar,
     )
     filenames_without_sync = []
     for filename, size, last_modified_datetime, etag in raw_filenames:
@@ -456,6 +463,7 @@ def _list_files_on_marine_data_lake_s3(
     bucket: str,
     prefix: str,
     recursive: bool,
+    disable_progress_bar: bool,
 ) -> list[tuple[str, int, DateTime, str]]:
     s3_client, _ = get_configured_boto3_session(
         endpoint_url, ["ListObjects"], username
@@ -469,7 +477,10 @@ def _list_files_on_marine_data_lake_s3(
     )
     logger.info("Listing files on remote server...")
     s3_objects = chain(
-        *map(lambda page: page.get("Contents", []), tqdm(page_iterator))
+        *map(
+            lambda page: page.get("Contents", []),
+            tqdm(page_iterator, disable=disable_progress_bar),
+        )
     )
     files_already_found: list[tuple[str, int, DateTime, str]] = []
     for s3_object in s3_objects:


### PR DESCRIPTION
From ticket [CMT-108](https://cms-change.atlassian.net/browse/CMT-108), were a get was being done and the toolbox was taking so long, we thought that it might be interesting to add, as an output, some sort of information about the process that is being done underneath.

This might help users understand that, although it will take a while, it will eventually reach and download the files.