### PR TITLE
add repository package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Copernicus Marine User Support <servicedesk.cmems@mercator-ocean.eu>
 readme = "README.md"
 packages = [{include = "copernicusmarine"}]
 license = "EUPL-1.2"
+repository = "https://github.com/mercator-ocean/copernicus-marine-toolbox"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 packages = [{include = "copernicusmarine"}]
 license = "EUPL-1.2"
 repository = "https://github.com/mercator-ocean/copernicus-marine-toolbox"
+documentation = "https://toolbox-docs.marine.copernicus.eu/"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"


### PR DESCRIPTION
add the repository field in the package metadta, so that PyPI will automatically add it to the package page and improve discoverability of the repository.