### PR TITLE
chore: update the deprecation for v2

### DIFF
--- a/copernicusmarine/catalogue_parser/request_structure.py
+++ b/copernicusmarine/catalogue_parser/request_structure.py
@@ -136,17 +136,16 @@ def subset_request_from_file(filepath: pathlib.Path) -> SubsetRequest:
     json_with_deprecated_options_replace = {}
 
     for key, val in json_content.items():
-        if key in DEPRECATED_OPTIONS:
+        if key in MAPPING_REQUEST_FILES_AND_REQUEST_OPTIONS:
+            new_key = MAPPING_REQUEST_FILES_AND_REQUEST_OPTIONS[key]
+            json_with_deprecated_options_replace[new_key] = val
+        elif key in DEPRECATED_OPTIONS:
             deprecated_option = DEPRECATED_OPTIONS[key]
             json_with_deprecated_options_replace[
                 deprecated_option.new_name
             ] = val
-        elif key in MAPPING_REQUEST_FILES_AND_REQUEST_OPTIONS:
-            new_key = MAPPING_REQUEST_FILES_AND_REQUEST_OPTIONS[key]
-            json_with_deprecated_options_replace[new_key] = val
         else:
             json_with_deprecated_options_replace[key] = val
-
     subset_request = SubsetRequest()
     subset_request.__dict__.update(json_with_deprecated_options_replace)
     subset_request.enforce_types()

--- a/copernicusmarine/command_line_interface/group_login.py
+++ b/copernicusmarine/command_line_interface/group_login.py
@@ -7,6 +7,9 @@ import click
 from copernicusmarine.command_line_interface.exception_handler import (
     log_exception_and_exit,
 )
+from copernicusmarine.core_functions.deprecated import (
+    DeprecatedClickOptionsCommand,
+)
 from copernicusmarine.core_functions.login import login_function
 from copernicusmarine.core_functions.utils import DEFAULT_CLIENT_BASE_DIRECTORY
 
@@ -20,6 +23,7 @@ def cli_group_login() -> None:
 
 @cli_group_login.command(
     "login",
+    cls=DeprecatedClickOptionsCommand,
     short_help="Create a configuration file with your Copernicus Marine credentials.",
     help="""
     Create a configuration file with your Copernicus Marine credentials.

--- a/copernicusmarine/core_functions/deprecated.py
+++ b/copernicusmarine/core_functions/deprecated.py
@@ -31,6 +31,8 @@ def get_deprecated_message(
         message += (
             "This option will no longer be "
             + "available in copernicusmarine>=2.0.0. "
+            + "Please refer to the documentation for more information "
+            + "when the new major version is released."
         )
     if deprecated_for_v2:
         message += (

--- a/copernicusmarine/core_functions/deprecated.py
+++ b/copernicusmarine/core_functions/deprecated.py
@@ -31,8 +31,8 @@ def get_deprecated_message(
         message += (
             "This option will no longer be "
             + "available in copernicusmarine>=2.0.0. "
-            + "Please refer to the documentation for more information "
-            + "when the new major version is released."
+            + "Please refer to the documentation when the new major "
+            + "version is released for more information."
         )
     if deprecated_for_v2:
         message += (

--- a/copernicusmarine/core_functions/deprecated.py
+++ b/copernicusmarine/core_functions/deprecated.py
@@ -5,17 +5,57 @@ from typing import Any, Callable, Dict
 
 import click
 
+from copernicusmarine.core_functions.deprecated_options import (
+    DEPRECATED_OPTIONS,
+    DeprecatedOptionMapping,
+)
+
 logger = logging.getLogger("copernicus_marine_root_logger")
 
 
-def get_deprecated_message(old_value, preferred_value):
-    return (
-        f"'{old_value}' has been deprecated, use '{preferred_value}' instead"
+def get_deprecated_message(
+    old_value,
+    preferred_value,
+    deleted_for_v2: bool = False,
+    deprecated_for_v2: bool = False,
+    only_for_v2: bool = False,
+):
+    message = ""
+    if only_for_v2:
+        message = f"Deprecation warning for option `{old_value}`. "
+    else:
+        message = f"'{old_value}' has been deprecated. "
+    if old_value != preferred_value and not only_for_v2:
+        message += f"Use '{preferred_value}' instead. "
+    if deleted_for_v2:
+        message += (
+            "This option will no longer be "
+            + "available in copernicusmarine>=2.0.0. "
+        )
+    if deprecated_for_v2:
+        message += (
+            "This option will be deprecated in copernicusmarine>=2.0.0 i.e. "
+            + "it will not break but it might not have the expected effect."
+        )
+    return message
+
+
+def log_deprecated_message(
+    old_value,
+    preferred_value,
+    deleted_for_v2: bool,
+    deprecated_for_v2: bool,
+    only_for_v2: bool,
+):
+    logger.warning(
+        get_deprecated_message(
+            old_value,
+            preferred_value,
+            deleted_for_v2=deleted_for_v2,
+            deprecated_for_v2=deprecated_for_v2,
+            only_for_v2=only_for_v2,
+        )
     )
-
-
-def log_deprecated_message(old_value, preferred_value):
-    logger.warning(get_deprecated_message(old_value, preferred_value))
 
 
 def raise_both_old_and_new_value_error(old_value, new_value):
@@ -40,16 +80,17 @@ class DeprecatedClickOptionsCommand(click.Command):
         options = set(parser._short_opt.values())
         options |= set(parser._long_opt.values())
 
+        # get name of the command
+        command_name = ctx.command.name
+
         for option in options:
-            if not isinstance(option.obj, DeprecatedClickOption):
-                continue
+            # if not isinstance(option.obj, DeprecatedClickOption):
+            #     continue
 
             def make_process(an_option):
                 orig_process = an_option.process
-                deprecated = getattr(an_option.obj, "deprecated", None)
-                preferred = getattr(an_option.obj, "preferred", None)
-                msg = "Expected `deprecated` value for `{}`"
-                assert deprecated is not None, msg.format(an_option.obj.name)
+                deprecated = getattr(an_option.obj, "deprecated", [])
+                preferred = getattr(an_option.obj, "preferred", [])
 
                 def process(value, state):
                     frame = inspect.currentframe()
@@ -57,9 +98,25 @@ class DeprecatedClickOptionsCommand(click.Command):
                         opt = frame.f_back.f_locals.get("opt")
                     finally:
                         del frame
-
-                    if opt in deprecated:
-                        log_deprecated_message(opt, preferred)
+                    old_alias = opt.replace("--", "").replace("-", "_")  # type: ignore
+                    if (
+                        opt in deprecated
+                        or old_alias
+                        in DEPRECATED_OPTIONS.deprecated_options_by_old_names
+                    ):
+                        alias_info = (
+                            DEPRECATED_OPTIONS.deprecated_options_by_old_names[
+                                old_alias
+                            ]
+                        )
+                        if command_name in alias_info.targeted_functions:
+                            log_deprecated_message(
+                                opt,
+                                preferred,
+                                alias_info.deleted_for_v2,
+                                alias_info.deprecated_for_v2,
+                                alias_info.only_for_v2,
+                            )
                     return orig_process(value, state)
 
                 return process
@@ -69,11 +126,13 @@ class DeprecatedClickOptionsCommand(click.Command):
         return parser
 
 
-def deprecated_python_option(**aliases: str) -> Callable:
+def deprecated_python_option(
+    deprecated_option: DeprecatedOptionMapping,
+) -> Callable:
     def deco(f: Callable):
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
-            rename_kwargs(f.__name__, kwargs, aliases)
+            rename_kwargs(f.__name__, kwargs, deprecated_option)
             return f(*args, **kwargs)
 
         return wrapper
@@ -82,11 +141,21 @@ def deprecated_python_option(**aliases: str) -> Callable:
 
 
 def rename_kwargs(
-    func_name: str, kwargs: Dict[str, Any], aliases: Dict[str, str]
+    func_name: str, kwargs: Dict[str, Any], aliases: DeprecatedOptionMapping
 ):
-    for alias, new in aliases.items():
-        if alias in kwargs:
-            if new in kwargs:
-                raise_both_old_and_new_value_error(alias, new)
-            log_deprecated_message(alias, new)
-            kwargs[new] = kwargs.pop(alias)
+    for old, alias_info in aliases.deprecated_options_by_old_names.items():
+        if func_name not in alias_info.targeted_functions:
+            continue
+        new = alias_info.new_name
+        if old in kwargs:
+            if new in kwargs and old != new:
+                raise_both_old_and_new_value_error(old, new)
+            log_deprecated_message(
+                old,
+                new,
+                alias_info.deleted_for_v2,
+                alias_info.deprecated_for_v2,
+                alias_info.only_for_v2,
+            )
+            if alias_info.replace:
+                kwargs[new] = kwargs.pop(old)

--- a/copernicusmarine/core_functions/deprecated.py
+++ b/copernicusmarine/core_functions/deprecated.py
@@ -37,7 +37,7 @@ def get_deprecated_message(
     if deprecated_for_v2:
         message += (
             "This option will be deprecated in copernicusmarine>=2.0.0 i.e. "
-            + "it will not break but it might not have the expected effect."
+            + "it will not break but it might have an unexpected effect."
         )
     return message
 
@@ -86,8 +86,6 @@ class DeprecatedClickOptionsCommand(click.Command):
         command_name = ctx.command.name
 
         for option in options:
-            # if not isinstance(option.obj, DeprecatedClickOption):
-            #     continue
 
             def make_process(an_option):
                 orig_process = an_option.process

--- a/copernicusmarine/core_functions/deprecated.py
+++ b/copernicusmarine/core_functions/deprecated.py
@@ -22,7 +22,7 @@ def get_deprecated_message(
 ):
     message = ""
     if only_for_v2:
-        message = f"Deprecation warning for option `{old_value}`. "
+        message = f"Deprecation warning for option '{old_value}'. "
     else:
         message = f"'{old_value}' has been deprecated. "
     if old_value != preferred_value and not only_for_v2:

--- a/copernicusmarine/core_functions/deprecated_options.py
+++ b/copernicusmarine/core_functions/deprecated_options.py
@@ -84,6 +84,13 @@ DEPRECATED_OPTIONS: DeprecatedOptionMapping = DeprecatedOptionMapping(
         ),
         DeprecatedOption(old_name="force_service", new_name="service"),
         DeprecatedOption(
+            old_name="service",
+            new_name="service",
+            deleted_for_v2=True,
+            only_for_v2=True,
+            targeted_functions=["get"],
+        ),
+        DeprecatedOption(
             old_name="download_file_list",
             new_name="create_file_list",
             replace=False,

--- a/copernicusmarine/core_functions/deprecated_options.py
+++ b/copernicusmarine/core_functions/deprecated_options.py
@@ -122,7 +122,7 @@ DEPRECATED_OPTIONS: DeprecatedOptionMapping = DeprecatedOptionMapping(
         DeprecatedOption(
             old_name="subset_method",
             new_name="coordinates_selection_method",
-            replace=False,  # TOCHECK
+            replace=False,
             only_for_v2=True,
         ),
         DeprecatedOption(
@@ -135,7 +135,7 @@ DEPRECATED_OPTIONS: DeprecatedOptionMapping = DeprecatedOptionMapping(
             new_name="disable_progress_bar",
             targeted_functions=["open_dataset", "read_dataframe"],
             only_for_v2=True,
-        ),  # TOCHECK: shouldn't be triggered for all
+        ),
         DeprecatedOption(
             old_name="include_datasets",
             new_name="include_datasets",

--- a/copernicusmarine/core_functions/deprecated_options.py
+++ b/copernicusmarine/core_functions/deprecated_options.py
@@ -86,6 +86,7 @@ DEPRECATED_OPTIONS: DeprecatedOptionMapping = DeprecatedOptionMapping(
         DeprecatedOption(
             old_name="service",
             new_name="service",
+            replace=False,
             deleted_for_v2=True,
             only_for_v2=True,
             targeted_functions=["get"],

--- a/copernicusmarine/core_functions/deprecated_options.py
+++ b/copernicusmarine/core_functions/deprecated_options.py
@@ -1,17 +1,40 @@
 from collections.abc import Iterator, Mapping
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 class DeprecatedOption:
-    def __init__(self, old_name, new_name, replace=True) -> None:
+    def __init__(
+        self,
+        old_name,
+        new_name,
+        replace=True,
+        deprecated_for_v2=False,
+        deleted_for_v2=True,
+        only_for_v2=False,
+        targeted_functions: Optional[list[str]] = None,
+    ) -> None:
         self.old_name = old_name
         self.new_name = new_name
         self.replace = replace
+        self.deprecated_for_v2 = deprecated_for_v2
+        self.deleted_for_v2 = deleted_for_v2
+        self.only_for_v2 = only_for_v2
+        if not targeted_functions:
+            self.targeted_functions = [
+                "describe",
+                "get",
+                "subset",
+                "login",
+                "open_dataset",
+                "read_dataframe",
+            ]
+        else:
+            self.targeted_functions = targeted_functions
 
 
 class DeprecatedOptionMapping(Mapping):
     def __init__(self, deprecated_options: List[DeprecatedOption]) -> None:
-        self.deprecated_options_by_old_names: Dict = {}
+        self.deprecated_options_by_old_names: Dict[str, DeprecatedOption] = {}
         for value in deprecated_options:
             if value not in self.deprecated_options_by_old_names:
                 self.deprecated_options_by_old_names[value.old_name] = value
@@ -68,6 +91,71 @@ DEPRECATED_OPTIONS: DeprecatedOptionMapping = DeprecatedOptionMapping(
         DeprecatedOption(
             old_name="include_all_versions",
             new_name="include_versions",
+        ),
+        DeprecatedOption(
+            old_name="skip_if_user_logged_in",
+            new_name="skip_if_user_logged_in",
+            only_for_v2=True,
+        ),
+        DeprecatedOption(
+            old_name="overwrite_metadata_cache",
+            new_name="overwrite_metadata_cache",
+            only_for_v2=True,
+        ),
+        DeprecatedOption(
+            old_name="no_metadata_cache",
+            new_name="no_metadata_cache",
+            only_for_v2=True,
+        ),
+        DeprecatedOption(
+            old_name="dataset_url",
+            new_name="dataset_url",
+            only_for_v2=True,
+        ),
+        DeprecatedOption(
+            old_name="subset_method",
+            new_name="coordinates_selection_method",
+            replace=False,  # TOCHECK
+            only_for_v2=True,
+        ),
+        DeprecatedOption(
+            old_name="netcdf_compression_enabled",
+            new_name="netcdf_compression_enabled",
+            only_for_v2=True,
+        ),
+        DeprecatedOption(
+            old_name="disable_progress_bar",
+            new_name="disable_progress_bar",
+            targeted_functions=["open_dataset", "read_dataframe"],
+            only_for_v2=True,
+        ),  # TOCHECK: shouldn't be triggered for all
+        DeprecatedOption(
+            old_name="include_datasets",
+            new_name="include_datasets",
+            deprecated_for_v2=True,
+            deleted_for_v2=False,
+            only_for_v2=True,
+        ),
+        DeprecatedOption(
+            old_name="include_description",
+            new_name="include_description",
+            deprecated_for_v2=True,
+            deleted_for_v2=False,
+            only_for_v2=True,
+        ),
+        DeprecatedOption(
+            old_name="include_keywords",
+            new_name="include_keywords",
+            deprecated_for_v2=True,
+            deleted_for_v2=False,
+            only_for_v2=True,
+        ),
+        DeprecatedOption(
+            old_name="include_all",
+            new_name="include_all",
+            deprecated_for_v2=True,
+            deleted_for_v2=False,
+            only_for_v2=True,
         ),
     ]
 )

--- a/copernicusmarine/python_interface/describe.py
+++ b/copernicusmarine/python_interface/describe.py
@@ -11,7 +11,7 @@ from copernicusmarine.python_interface.exception_handler import (
 )
 
 
-@deprecated_python_option(**DEPRECATED_OPTIONS.dict_old_names_to_new_names)
+@deprecated_python_option(DEPRECATED_OPTIONS)
 @log_exception_and_exit
 def describe(
     include_description: bool = False,

--- a/copernicusmarine/python_interface/get.py
+++ b/copernicusmarine/python_interface/get.py
@@ -15,7 +15,7 @@ from copernicusmarine.python_interface.exception_handler import (
 )
 
 
-@deprecated_python_option(**DEPRECATED_OPTIONS.dict_old_names_to_new_names)
+@deprecated_python_option(DEPRECATED_OPTIONS)
 @log_exception_and_exit
 def get(
     dataset_url: Optional[str] = None,
@@ -89,7 +89,13 @@ def get(
             "download_file_list", "create_file_list"
         )
     elif download_file_list:
-        log_deprecated_message("download_file_list", "create_file_list")
+        log_deprecated_message(
+            "download_file_list",
+            "create_file_list",
+            deleted_for_v2=True,
+            deprecated_for_v2=False,
+            only_for_v2=False,
+        )
     return get_function(
         dataset_url=dataset_url,
         dataset_id=dataset_id,

--- a/copernicusmarine/python_interface/login.py
+++ b/copernicusmarine/python_interface/login.py
@@ -1,10 +1,15 @@
 import pathlib
 from typing import Optional
 
+from copernicusmarine.core_functions.deprecated import deprecated_python_option
+from copernicusmarine.core_functions.deprecated_options import (
+    DEPRECATED_OPTIONS,
+)
 from copernicusmarine.core_functions.login import login_function
 from copernicusmarine.core_functions.utils import DEFAULT_CLIENT_BASE_DIRECTORY
 
 
+@deprecated_python_option(DEPRECATED_OPTIONS)
 def login(
     username: Optional[str] = None,
     password: Optional[str] = None,

--- a/copernicusmarine/python_interface/open_dataset.py
+++ b/copernicusmarine/python_interface/open_dataset.py
@@ -40,11 +40,17 @@ def load_xarray_dataset(*args, **kwargs):
     """
     Deprecated function, use 'open_dataset' instead.
     """
-    log_deprecated_message("load_xarray_dataset", "open_dataset")
+    log_deprecated_message(
+        "load_xarray_dataset",
+        "open_dataset",
+        deleted_for_v2=True,
+        deprecated_for_v2=False,
+        only_for_v2=False,
+    )
     return open_dataset(*args, **kwargs)
 
 
-@deprecated_python_option(**DEPRECATED_OPTIONS.dict_old_names_to_new_names)
+@deprecated_python_option(DEPRECATED_OPTIONS)
 @log_exception_and_exit
 def open_dataset(
     dataset_url: Optional[str] = None,

--- a/copernicusmarine/python_interface/read_dataframe.py
+++ b/copernicusmarine/python_interface/read_dataframe.py
@@ -40,11 +40,17 @@ def load_pandas_dataframe(*args, **kwargs):
     """
     Deprecated function, use 'read_dataframe' instead.
     """
-    log_deprecated_message("load_pandas_dataframe", "read_dataframe")
+    log_deprecated_message(
+        "load_pandas_dataframe",
+        "read_dataframe",
+        deleted_for_v2=True,
+        deprecated_for_v2=False,
+        only_for_v2=False,
+    )
     return read_dataframe(*args, **kwargs)
 
 
-@deprecated_python_option(**DEPRECATED_OPTIONS.dict_old_names_to_new_names)
+@deprecated_python_option(DEPRECATED_OPTIONS)
 @log_exception_and_exit
 def read_dataframe(
     dataset_url: Optional[str] = None,

--- a/copernicusmarine/python_interface/subset.py
+++ b/copernicusmarine/python_interface/subset.py
@@ -19,7 +19,7 @@ from copernicusmarine.python_interface.exception_handler import (
 from copernicusmarine.python_interface.utils import homogenize_datetime
 
 
-@deprecated_python_option(**DEPRECATED_OPTIONS.dict_old_names_to_new_names)
+@deprecated_python_option(DEPRECATED_OPTIONS)
 @log_exception_and_exit
 def subset(
     dataset_url: Optional[str] = None,

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -1030,10 +1030,10 @@ class TestCommandLineInterface:
     def then_I_got_an_error_regarding_mutual_exclusivity(self):
         assert self.output.returncode == 2
         assert self.output.stdout == b""
-        assert self.output.stderr == (
+        assert (
             b"Error: Illegal usage: `overwrite-metadata-cache` is mutually "
             b"exclusive with arguments `no-metadata-cache`.\n"
-        )
+        ) in self.output.stderr
 
     def test_describe_without_using_cache(self):
         command = ["copernicusmarine", "describe", "--no-metadata-cache"]

--- a/tests/test_deprecated_options.py
+++ b/tests/test_deprecated_options.py
@@ -76,8 +76,8 @@ class TestDeprecatedOptions:
         self.output = execute_in_terminal(command)
         assert b"WARNING" in self.output.stderr
         assert (
-            b"'--include-all-versions' has been deprecated, "
-            b"use '--include-versions' instead"
+            b"'--include-all-versions' has been deprecated. "
+            b"Use '--include-versions' instead"
         ) in self.output.stderr
         assert self.output.returncode == 0
 

--- a/tests/test_get_create_file_list.py
+++ b/tests/test_get_create_file_list.py
@@ -15,8 +15,8 @@ class TestGetCreateFileList:
         ]
         self.output = execute_in_terminal(self.command)
         assert (
-            b"'--download-file-list' has been deprecated, "
-            b"use '--create-file-list' instead" in self.output.stderr
+            b"'--download-file-list' has been deprecated. "
+            b"Use '--create-file-list' instead" in self.output.stderr
         )
 
     def test_get_create_file_list_without_extension_raises(self):


### PR DESCRIPTION
Add deprecation for options that will be deleted in v2. 

Added some different messages depending on the cases: 

- If it has a replacement already
- If it will be deleted or deprecated in the v2
- If it is only about the v2