### PR TITLE
fix: subset was not using staging metadata

### DIFF
--- a/copernicusmarine/core_functions/subset.py
+++ b/copernicusmarine/core_functions/subset.py
@@ -152,6 +152,7 @@ def subset_function(
         subset_request.force_service,
         CommandType.SUBSET,
         dataset_subset=subset_request.get_time_and_space_subset(),
+        staging=staging,
     )
     subset_request.dataset_url = retrieval_service.uri
     check_dataset_subset_bounds(

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -1860,3 +1860,37 @@ class TestCommandLineInterface:
         assert datetime.datetime.strptime(
             str(dataset.time.values.max()), "%Y-%m-%dT%H:%M:%S.000%f"
         ) >= datetime.datetime.strptime("2023-01-03", "%Y-%m-%d")
+
+    def test_get_goes_to_staging(self):
+        command = [
+            "copernicusmarine",
+            "get",
+            "--dataset-id",
+            "cmems_mod_ibi_phy_my_0.083deg-3D_P1Y-m",
+            "--staging",
+            "--log-level",
+            "DEBUG",
+        ]
+        self.output = execute_in_terminal(command)
+        assert (
+            b"mdl-metadata-dta/dataset_product_id_mapping.json"
+            in self.output.stderr
+        )
+
+    def test_subset_goes_to_staging(self):
+        command = [
+            "copernicusmarine",
+            "subset",
+            "--dataset-id",
+            "cmems_mod_ibi_phy_my_0.083deg-3D_P1Y-m",
+            "--variable",
+            "thetao",
+            "--staging",
+            "--log-level",
+            "DEBUG",
+        ]
+        self.output = execute_in_terminal(command)
+        assert (
+            b"mdl-metadata-dta/dataset_product_id_mapping.json"
+            in self.output.stderr
+        )


### PR DESCRIPTION
Even with `copernicusmarine subset --staging` the command was not getting the dataset from staging

Bug introduced when got rid of the cache