### PR TITLE
fix: wrong name status file in the doc

### DIFF
--- a/copernicusmarine/core_functions/models.py
+++ b/copernicusmarine/core_functions/models.py
@@ -60,7 +60,7 @@ class FileStatus(str, Enum):
 
     #: The file has been downloaded successfully.
     DOWNLOADED = "DOWNLOADED"
-    #: The file has been ignored.
+    #: The file has been ignored. Probably because it already exists.
     IGNORED = "IGNORED"
     #: The file has been overwritten and downloaded.
     OVERWRITTEN = "OVERWRITTEN"

--- a/doc/response-types.rst
+++ b/doc/response-types.rst
@@ -143,7 +143,7 @@ Subtypes
     :exclude-members: model_computed_fields, model_config, model_fields
     :member-order: bysource
 
-.. autoclass:: copernicusmarine.StatusFile()
+.. autoclass:: copernicusmarine.FileStatus()
     :members:
     :undoc-members:
     :exclude-members: model_computed_fields, model_config, model_fields


### PR DESCRIPTION
Fix the doc where a name wasn't changed