### PR TITLE
chore: reordering options

### DIFF
--- a/copernicusmarine/command_line_interface/group_subset.py
+++ b/copernicusmarine/command_line_interface/group_subset.py
@@ -242,13 +242,6 @@ def cli_subset() -> None:
     default=None,
     help=documentation_utils.GET["RESPONSE_FIELDS_HELP"],
 )
-@tqdm_disable_option
-@click.option(
-    "--log-level",
-    type=click.Choice(["DEBUG", "INFO", "WARN", "ERROR", "CRITICAL", "QUIET"]),
-    default="INFO",
-    help=documentation_utils.SUBSET["LOG_LEVEL_HELP"],
-)
 @click.option(
     "--netcdf-compression-level",
     type=click.IntRange(0, 9),
@@ -277,6 +270,13 @@ def cli_subset() -> None:
     default=False,
     is_flag=True,
     hidden=True,
+)
+@tqdm_disable_option
+@click.option(
+    "--log-level",
+    type=click.Choice(["DEBUG", "INFO", "WARN", "ERROR", "CRITICAL", "QUIET"]),
+    default="INFO",
+    help=documentation_utils.SUBSET["LOG_LEVEL_HELP"],
 )
 @log_exception_and_exit
 def subset(

--- a/copernicusmarine/python_interface/get.py
+++ b/copernicusmarine/python_interface/get.py
@@ -58,6 +58,8 @@ def get(
         The username for authentication.
     password : str, optional
         The password for authentication.
+    no_directories : bool, optional
+        If True, downloaded files will not be organized into directories.
     output_directory : Union[pathlib.Path, str], optional
         The destination folder for the downloaded files. Default is the current directory.
     credentials_file : Union[pathlib.Path, str], optional
@@ -66,8 +68,6 @@ def get(
         If specified and if the file already exists on destination, then it will be overwritten. By default, the toolbox creates a new file with a new index (eg 'filename_(1).nc').
     request_file : Union[pathlib.Path, str], optional
         Option to pass a file containing the arguments. For more information please refer to the documentation or use option ``--create-template`` from the command line interface for an example template.
-    no_directories : bool, optional
-        If True, downloaded files will not be organized into directories.
     filter : str, optional
         A pattern that must match the absolute paths of the files to download.
     regex : str, optional
@@ -76,14 +76,14 @@ def get(
         Path to a '.txt' file containing a list of file paths, line by line, that will be downloaded directly. These files must be from the same dataset as the one specified dataset with the datasetID option. If no files can be found, the Toolbox will list all files on the remote server and attempt to find a match.
     create_file_list : str, optional
         Option to only create a file containing the names of the targeted files instead of downloading them. It writes the file to the specified output directory (default to current directory). The file name specified should end with '.txt' or '.csv'. If specified, no other action will be performed.
-    index_parts : bool, optional
-        Option to get the index files of an INSITU dataset.
     sync : bool, optional
         Option to synchronize the local directory with the remote directory. See the documentation for more details.
     sync_delete : bool, optional
         Option to delete local files that are not present on the remote server while applying sync.
     skip_existing : bool, optional
         If the files already exists where it would be downloaded, then the download is skipped for this file. By default, the toolbox creates a new file with a new index (eg 'filename_(1).nc').
+    index_parts : bool, optional
+        Option to get the index files of an INSITU dataset.
     dry_run : bool, optional
         If True, runs query without downloading data.
     max_concurrent_requests : int, optional

--- a/copernicusmarine/python_interface/open_dataset.py
+++ b/copernicusmarine/python_interface/open_dataset.py
@@ -92,14 +92,14 @@ def open_dataset(
         Minimum depth for the subset. Requires a positive float (or 0).
     maximum_depth : float, optional
         Maximum depth for the subset. Requires a positive float (or 0).
-    coordinates_selection_method : str, optional
-        If ``inside``, the selection retrieved will be inside the requested range. If ``strict-inside``, the selection retrieved will be inside the requested range, and an error will be raised if the values don't exist. If ``nearest``, the extremes closest to the requested values will be returned. If ``outside``, the extremes will be taken to contain all the requested interval. The methods ``inside``, ``nearest`` and ``outside`` will display a warning if the request is out of bounds.
     vertical_axis : str, optional
         Consolidate the vertical dimension (the z-axis) as requested: depth with descending positive values, elevation with ascending positive values. Default is depth.
     start_datetime : Union[datetime, str], optional
         The start datetime of the temporal subset. Supports common format parsed by pendulum (https://pendulum.eustace.io/docs/#parsing).
     end_datetime : Union[datetime, str], optional
         The end datetime of the temporal subset. Supports common format parsed by pendulum (https://pendulum.eustace.io/docs/#parsing).
+    coordinates_selection_method : str, optional
+        If ``inside``, the selection retrieved will be inside the requested range. If ``strict-inside``, the selection retrieved will be inside the requested range, and an error will be raised if the values don't exist. If ``nearest``, the extremes closest to the requested values will be returned. If ``outside``, the extremes will be taken to contain all the requested interval. The methods ``inside``, ``nearest`` and ``outside`` will display a warning if the request is out of bounds.
     service : str, optional
         Force download through one of the available services using the service name among ['arco-geo-series', 'arco-time-series', 'omi-arco', 'static-arco'] or its short name among ['geoseries', 'timeseries', 'omi-arco', 'static-arco'].
     credentials_file : Union[pathlib.Path, str], optional

--- a/copernicusmarine/python_interface/subset.py
+++ b/copernicusmarine/python_interface/subset.py
@@ -79,18 +79,6 @@ def subset(
         The username for authentication. See also :func:`~copernicusmarine.login`
     password : str, optional
         The password for authentication. See also :func:`~copernicusmarine.login`
-    output_directory : Union[pathlib.Path, str], optional
-        The destination folder for the downloaded files. Default is the current directory.
-    credentials_file : Union[pathlib.Path, str], optional
-        Path to a credentials file if not in its default directory (``$HOME/.copernicusmarine``). Accepts .copernicusmarine-credentials / .netrc or _netrc / motuclient-python.ini files.
-    overwrite : bool, optional
-        If specified and if the file already exists on destination, then it will be overwritten. By default, the toolbox creates a new file with a new index (eg 'filename_(1).nc').
-    skip_existing : bool, optional
-        If the files already exists where it would be downloaded, then the download is skipped for this file. By default, the toolbox creates a new file with a new index (eg 'filename_(1).nc').
-    request_file : Union[pathlib.Path, str], optional
-        Option to pass a file containing the arguments. For more information please refer to the documentation or use option ``--create-template`` from the command line interface for an example template.
-    service : str, optional
-        Force download through one of the available services using the service name among ['arco-geo-series', 'arco-time-series', 'omi-arco', 'static-arco'] or its short name among ['geoseries', 'timeseries', 'omi-arco', 'static-arco'].
     variables : List[str], optional
         List of variable names to extract.
     minimum_longitude : float, optional
@@ -113,10 +101,22 @@ def subset(
         The end datetime of the temporal subset. Supports common format parsed by pendulum (https://pendulum.eustace.io/docs/#parsing).
     coordinates_selection_method : str, optional
         If ``inside``, the selection retrieved will be inside the requested range. If ``strict-inside``, the selection retrieved will be inside the requested range, and an error will be raised if the values don't exist. If ``nearest``, the extremes closest to the requested values will be returned. If ``outside``, the extremes will be taken to contain all the requested interval. The methods ``inside``, ``nearest`` and ``outside`` will display a warning if the request is out of bounds.
+    output_directory : Union[pathlib.Path, str], optional
+        The destination folder for the downloaded files. Default is the current directory.
+    credentials_file : Union[pathlib.Path, str], optional
+        Path to a credentials file if not in its default directory (``$HOME/.copernicusmarine``). Accepts .copernicusmarine-credentials / .netrc or _netrc / motuclient-python.ini files.
     output_filename : str, optional
         Save the downloaded data with the given file name (under the output directory).
     file_format : str, optional
         Format of the downloaded dataset. Default to NetCDF '.nc'.
+    overwrite : bool, optional
+        If specified and if the file already exists on destination, then it will be overwritten. By default, the toolbox creates a new file with a new index (eg 'filename_(1).nc').
+    skip_existing : bool, optional
+        If the files already exists where it would be downloaded, then the download is skipped for this file. By default, the toolbox creates a new file with a new index (eg 'filename_(1).nc').
+    service : str, optional
+        Force download through one of the available services using the service name among ['arco-geo-series', 'arco-time-series', 'omi-arco', 'static-arco'] or its short name among ['geoseries', 'timeseries', 'omi-arco', 'static-arco'].
+    request_file : Union[pathlib.Path, str], optional
+        Option to pass a file containing the arguments. For more information please refer to the documentation or use option ``--create-template`` from the command line interface for an example template.
     motu_api_request : str, optional
         Option to pass a complete MOTU API request as a string. Caution, user has to replace double quotes “ with single quotes ' in the request.
     dry_run : bool, optional

--- a/doc/python-interface.rst
+++ b/doc/python-interface.rst
@@ -3,4 +3,4 @@ Python interface
 =================
 
 .. automodule:: copernicusmarine
-   :members: get, subset, describe, open_dataset, read_dataframe, login
+   :members: subset, get, describe, open_dataset, read_dataframe, login


### PR DESCRIPTION
Reordering the options in which the parameters appear in the documentation. So:
subset.cli options are ordered the same as subset.api.

I didn't order equally the cli page with the api page because I prefer the order in the cli but it is hard to change the order of the API, and maybe not the highest priority to invest my time in this. Will rest as a TODO.