### PR TITLE
fix: netcdf compression solved

### DIFF
--- a/copernicusmarine/command_line_interface/group_subset.py
+++ b/copernicusmarine/command_line_interface/group_subset.py
@@ -249,7 +249,7 @@ def cli_subset() -> None:
     flag_value=4,
     default=0,
     help=documentation_utils.SUBSET["NETCDF_COMPRESSION_LEVEL_HELP"]
-    + " If used as a flag, the assigned value will be 1.",
+    + " If used as a flag, the assigned value will be 4.",
 )
 @click.option(
     "--netcdf3-compatible",

--- a/copernicusmarine/command_line_interface/group_subset.py
+++ b/copernicusmarine/command_line_interface/group_subset.py
@@ -246,7 +246,7 @@ def cli_subset() -> None:
     "--netcdf-compression-level",
     type=click.IntRange(0, 9),
     is_flag=False,
-    flag_value=1,
+    flag_value=4,
     default=0,
     help=documentation_utils.SUBSET["NETCDF_COMPRESSION_LEVEL_HELP"]
     + " If used as a flag, the assigned value will be 1.",

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -559,8 +559,8 @@ def _download_dataset_as_netcdf(
         encoding = {
             name: {
                 **{
-                    key: var.encoding[key]
-                    for key in var.encoding.keys()
+                    key: value
+                    for key, value in var.encoding.items()
                     if key in keys_to_keep
                 },
                 **comp,

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -495,7 +495,6 @@ def _save_dataset_locally(
     netcdf_compression_level: int,
     netcdf3_compatible: bool,
 ):
-    logger.info(output_path)
     if output_path.suffix == ".zarr":
         if netcdf_compression_level > 0:
             raise NetCDFCompressionNotAvailable(

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -539,22 +539,30 @@ def _download_dataset_as_netcdf(
             contiguous=False,
             shuffle=True,
         )
-        encoding = {
+        long_encoding = {
             name: {**var.encoding, **comp}
             for name, var in dataset.data_vars.items()
         }
         for var in dataset.data_vars:
-            for key in [
-                "szip",
-                "zstd",
-                "bzip2",
-                "blosc",
-                "preferred_chunks",
-                "compressor",
-                "filters",
-                "coordinates",
-            ]:
-                encoding[var].pop(key, None)
+            keys_to_keep = [
+                "dtype",
+                "blosc_shuffle",
+                "shuffle",
+                "chunksizes",
+                "szip_coding",
+                "zlib",
+                "_FillValue",
+                "significant_digits",
+                "fletcher32",
+                "contiguous",
+                "szip_pixels_per_block",
+                "complevel",
+                "compression_opts",
+                "compression",
+                "quantize_mode",
+                "endian",
+            ]
+            encoding = {key: long_encoding[var][key] for key in keys_to_keep}
     else:
         encoding = None
 

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -552,6 +552,7 @@ def _download_dataset_as_netcdf(
                 "preferred_chunks",
                 "compressor",
                 "filters",
+                "coordinates",
             ]:
                 encoding[var].pop(key, None)
     else:

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -539,25 +539,32 @@ def _download_dataset_as_netcdf(
             shuffle=True,
         )
         keys_to_keep = {
-    "_FillValue",
-    "blosc_shuffle",
-    "chunksizes",
-    "complevel",
-    "compression",
-    "compression_opts",
-    "contiguous",
-    "dtype",
-    "endian",
-    "fletcher32",
-    "quantize_mode",
-    "shuffle",
-    "significant_digits",
-    "szip_coding",
-    "szip_pixels_per_block",
-    "zlib",
-}
+            "_FillValue",
+            "blosc_shuffle",
+            "chunksizes",
+            "complevel",
+            "compression",
+            "compression_opts",
+            "contiguous",
+            "dtype",
+            "endian",
+            "fletcher32",
+            "quantize_mode",
+            "shuffle",
+            "significant_digits",
+            "szip_coding",
+            "szip_pixels_per_block",
+            "zlib",
+        }
         encoding = {
-            name: {**{key: value for key, value in var.encoding if key in keys_to_keep}, **comp}
+            name: {
+                **{
+                    key: var.encoding[key]
+                    for key in var.encoding.keys()
+                    if key in keys_to_keep
+                },
+                **comp,
+            }
             for name, var in dataset.data_vars.items()
         }
     else:

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -543,7 +543,7 @@ def _download_dataset_as_netcdf(
             name: {**var.encoding, **comp}
             for name, var in dataset.data_vars.items()
         }
-        print(long_encoding)
+        encoding = {}
         for var in dataset.data_vars:
             keys_to_keep = [
                 "dtype",
@@ -563,9 +563,9 @@ def _download_dataset_as_netcdf(
                 "quantize_mode",
                 "endian",
             ]
-            encoding = {
+            encoding[var] = {
                 key: long_encoding[var][key]
-                for key in long_encoding[var].items()
+                for key in long_encoding[var].keys()
                 if key in keys_to_keep
             }
     else:

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -543,11 +543,12 @@ def _download_dataset_as_netcdf(
             name: {**var.encoding, **comp}
             for name, var in dataset.data_vars.items()
         }
+        print(long_encoding)
         for var in dataset.data_vars:
             keys_to_keep = [
                 "dtype",
-                "blosc_shuffle",
                 "shuffle",
+                "blosc_shuffle",
                 "chunksizes",
                 "szip_coding",
                 "zlib",
@@ -562,7 +563,11 @@ def _download_dataset_as_netcdf(
                 "quantize_mode",
                 "endian",
             ]
-            encoding = {key: long_encoding[var][key] for key in keys_to_keep}
+            encoding = {
+                key: long_encoding[var][key]
+                for key in long_encoding[var].items()
+                if key in keys_to_keep
+            }
     else:
         encoding = None
 

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -495,6 +495,7 @@ def _save_dataset_locally(
     netcdf_compression_level: int,
     netcdf3_compatible: bool,
 ):
+    logger.info(output_path)
     if output_path.suffix == ".zarr":
         if netcdf_compression_level > 0:
             raise NetCDFCompressionNotAvailable(
@@ -538,7 +539,21 @@ def _download_dataset_as_netcdf(
             contiguous=False,
             shuffle=True,
         )
-        encoding = {var: comp for var in dataset.data_vars}
+        encoding = {
+            name: {**var.encoding, **comp}
+            for name, var in dataset.data_vars.items()
+        }
+        for var in dataset.data_vars:
+            for key in [
+                "szip",
+                "zstd",
+                "bzip2",
+                "blosc",
+                "preferred_chunks",
+                "compressor",
+                "filters",
+            ]:
+                encoding[var].pop(key, None)
     else:
         encoding = None
 

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -538,35 +538,28 @@ def _download_dataset_as_netcdf(
             contiguous=False,
             shuffle=True,
         )
-        long_encoding = {
-            name: {**var.encoding, **comp}
+        keys_to_keep = {
+    "_FillValue",
+    "blosc_shuffle",
+    "chunksizes",
+    "complevel",
+    "compression",
+    "compression_opts",
+    "contiguous",
+    "dtype",
+    "endian",
+    "fletcher32",
+    "quantize_mode",
+    "shuffle",
+    "significant_digits",
+    "szip_coding",
+    "szip_pixels_per_block",
+    "zlib",
+}
+        encoding = {
+            name: {**{key: value for key, value in var.encoding if key in keys_to_keep}, **comp}
             for name, var in dataset.data_vars.items()
         }
-        encoding = {}
-        for var in dataset.data_vars:
-            keys_to_keep = [
-                "dtype",
-                "shuffle",
-                "blosc_shuffle",
-                "chunksizes",
-                "szip_coding",
-                "zlib",
-                "_FillValue",
-                "significant_digits",
-                "fletcher32",
-                "contiguous",
-                "szip_pixels_per_block",
-                "complevel",
-                "compression_opts",
-                "compression",
-                "quantize_mode",
-                "endian",
-            ]
-            encoding[var] = {
-                key: long_encoding[var][key]
-                for key in long_encoding[var].keys()
-                if key in keys_to_keep
-            }
     else:
         encoding = None
 

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -62,7 +62,7 @@ Default NetCDF compression settings for xarray:
 
 .. code-block:: text
 
-    {'zlib': True, 'complevel': 1, 'contiguous': False, 'shuffle': True}
+    {'zlib': True, 'complevel': 4, 'contiguous': False, 'shuffle': True}
 
 Set the ``--netcdf-compression-level`` to a custom compression level between 0 (no compression, by default) and 9 (maximum compression).
 

--- a/tests/__snapshots__/test_help_command_interface.ambr
+++ b/tests/__snapshots__/test_help_command_interface.ambr
@@ -365,7 +365,7 @@
     '                                  NetCDF output file. A value of 0 means no',
     '                                  compression, and 9 is the highest level of',
     '                                  compression available. If used as a flag,',
-    '                                  the assigned value will be 1.  [0<=x<=9]',
+    '                                  the assigned value will be 4.  [0<=x<=9]',
     '  --netcdf3-compatible            Enable downloading the dataset in a netCDF3',
     '                                  compatible format.',
     '  --chunk-size-limit INTEGER RANGE',

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -1277,7 +1277,7 @@ class TestCommandLineInterface:
         assert dataset_without_option.uo.encoding["complevel"] == 0
 
         assert dataset_with_option.uo.encoding["zlib"] is True
-        assert dataset_with_option.uo.encoding["complevel"] == 1
+        assert dataset_with_option.uo.encoding["complevel"] == 4
         assert dataset_with_option.uo.encoding["contiguous"] is False
         assert dataset_with_option.uo.encoding["shuffle"] is True
 

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -1281,6 +1281,54 @@ class TestCommandLineInterface:
         assert dataset_with_option.uo.encoding["contiguous"] is False
         assert dataset_with_option.uo.encoding["shuffle"] is True
 
+    def test_netcdf_compression_with_optimised_files(self, tmp_path):
+        filename_without_option = "without_option.nc"
+        filename_with_option = "with_option.nc"
+
+        netcdf_compression_option = "--netcdf-compression-level"
+
+        base_command = [
+            "copernicusmarine",
+            "subset",
+            "-i",
+            "cmems_mod_glo_phy_my_0.083deg_P1D-m",
+            "-x",
+            "3.08",
+            "-X",
+            "3.17",
+            "-y",
+            "-35",
+            "-Y",
+            "-30",
+            "-t",
+            "1993-01-01T00:00:00",
+            "-T",
+            "1995-01-31T00:00:00",
+            "-v",
+            "thetao",
+            "-o",
+            f"{tmp_path}",
+        ]
+
+        output_without_option = execute_in_terminal(
+            base_command + ["-f", filename_without_option]
+        )
+        output_with_option = execute_in_terminal(
+            base_command
+            + ["-f", filename_with_option, netcdf_compression_option]
+        )
+
+        assert output_without_option.returncode == 0
+        assert output_with_option.returncode == 0
+
+        filepath_without_option = Path(tmp_path / filename_without_option)
+        filepath_with_option = Path(tmp_path / filename_with_option)
+
+        size_without_option = get_file_size(filepath_without_option)
+        size_with_option = get_file_size(filepath_with_option)
+        logger.info(f"{size_without_option=}, {size_with_option=}")
+        assert 4 * size_with_option < size_without_option
+
     def test_omi_arco_service(self, tmp_path):
         base_command = [
             "copernicusmarine",


### PR DESCRIPTION
With the help of xarray developers in [Issue #9783](https://github.com/pydata/xarray/issues/9783) we solved the issue with the encoding for netcdf datasets (it looked like it was already pretty well compressed and we were not sending all the information to the output).

I also changed the default value to 4 for the CLI subset because from [here](https://unidata.github.io/netcdf4-python/#netCDF4.Dataset.createVariable) it looked like the default compression value for xarray is also 4.

Looks like now, indeed, the 3 commands are saving the files with 'according' sizes:
```
copernicusmarine subset --dataset-id cmems_mod_glo_phy_my_0.083deg_P1D-m -v thetao -t 1993-01-01T00:00:00 -T 2020-12-31T23:59:59 -x -90 -X -85 -y -35 -Y -30 -z 0.49 -Z 1 --netcdf-compression-level 1 -f comlevel1.nc

copernicusmarine subset --dataset-id cmems_mod_glo_phy_my_0.083deg_P1D-m -v thetao -t 1993-01-01T00:00:00 -T 2020-12-31T23:59:59 -x -90 -X -85 -y -35 -Y -30 -z 0.49 -Z 1 -f complevel0.nc

copernicusmarine subset --dataset-id cmems_mod_glo_phy_my_0.083deg_P1D-m -v thetao -t 1993-01-01T00:00:00 -T 2020-12-31T23:59:59 -x -90 -X -85 -y -35 -Y -30 -z 0.49 -Z 1 --netcdf3-compatible -f netcdf3.nc
```