### PR TITLE
fix: updating link for the binaries

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -92,10 +92,12 @@ In the `release page <https://github.com/mercator-ocean/copernicus-marine-toolbo
 
 To download directly the latest stable releases:
 
-- MacOS arm64: `copernicusmarine_macos-arm64 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v2.0.0a3/copernicusmarine_macos-arm64.cli>`_
-- MacOS x86_64: `copernicusmarine_macos-x86_64 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v2.0.0a3/copernicusmarine_macos-x86_64.cli>`_
-- Linux: `copernicusmarine_linux <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v2.0.0a3/copernicusmarine_linux.cli>`_
-- Windows: `copernicusmarine <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v2.0.0a3/copernicusmarine.exe>`_
+- MacOS arm64: `copernicusmarine_macos-arm64 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/latest/copernicusmarine_macos-arm64.cli>`_
+- MacOS x86_64: `copernicusmarine_macos-x86_64 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/latest/copernicusmarine_macos-x86_64.cli>`_
+- Linux (with glibc 2.35): `copernicusmarine_linux <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/latest/copernicusmarine_linux-glibc-2.35.cli>`_
+- Linux (with glibc 2.31): `copernicusmarine_linux <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/latest/copernicusmarine_linux-glibc-2.31.cli>`_
+- Windows: `copernicusmarine <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/latest/copernicusmarine.exe>`_
+
 
 Once downloaded for the specific platform, you can use the toolbox by running the binary as follows:
 
@@ -103,7 +105,7 @@ In mac-os or linux:
 
 .. code-block:: bash
 
-    ./copernicusmarine_macos-latest.cli describe
+    ./copernicusmarine_macos-x86_64.cli describe
 
 (``describe`` or any other command)
 
@@ -111,13 +113,13 @@ You might have to update the permissions of the binary to be able to execute it 
 
 .. code-block:: bash
 
-    chmod +rwx cmt_ubuntu-latest.cli
+    chmod +rwx copernicusmarine_linux-glibc-2.31.cli
 
 And from a Windows os (cmd):
 
 .. code-block:: bash
 
-    copernicusmarine_windows-latest.exe describe
+    copernicusmarine.exe describe
 
 (``describe`` or any other command)
 


### PR DESCRIPTION
Updating the binaries link in the documentation for the following release.

I'm not sure I like it fully because the link will not work properly for future pre-releases (that is also why I hardcoded them before). I will check it in the future.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--219.org.readthedocs.build/en/219/

<!-- readthedocs-preview copernicusmarine end -->