### PR TITLE
chore: syncing parts allowed

### DIFF
--- a/copernicusmarine/core_functions/get.py
+++ b/copernicusmarine/core_functions/get.py
@@ -152,7 +152,6 @@ def _run_get_request(
         get_request.force_dataset_part,
         None,
         CommandType.GET,
-        get_request.index_parts,
         dataset_sync=get_request.sync,
         staging=staging,
     )

--- a/copernicusmarine/core_functions/services_utils.py
+++ b/copernicusmarine/core_functions/services_utils.py
@@ -272,7 +272,6 @@ def get_retrieval_service(
     force_dataset_part_label: Optional[str],
     force_service_name_or_short_name: Optional[str],
     command_type: CommandType,
-    index_parts: bool = False,
     dataset_subset: Optional[DatasetTimeAndSpaceSubset] = None,
     dataset_sync: bool = False,
     username: Optional[str] = None,
@@ -300,7 +299,6 @@ def get_retrieval_service(
         force_dataset_part_label=force_dataset_part_label,
         force_service_name=force_service_name,
         command_type=command_type,
-        index_parts=index_parts,
         dataset_subset=dataset_subset,
         dataset_sync=dataset_sync,
         username=username,
@@ -313,7 +311,6 @@ def _get_retrieval_service_from_dataset(
     force_dataset_part_label: Optional[str],
     force_service_name: Optional[CopernicusMarineServiceNames],
     command_type: CommandType,
-    index_parts: bool,
     dataset_subset: Optional[DatasetTimeAndSpaceSubset],
     dataset_sync: bool,
     username: Optional[str],
@@ -335,7 +332,6 @@ def _get_retrieval_service_from_dataset(
         force_dataset_part_label=force_dataset_part_label,
         force_service_name=force_service_name,
         command_type=command_type,
-        index_parts=index_parts,
         dataset_subset=dataset_subset,
         dataset_sync=dataset_sync,
         username=username,
@@ -348,15 +344,10 @@ def _get_retrieval_service_from_dataset_version(
     force_dataset_part_label: Optional[str],
     force_service_name: Optional[CopernicusMarineServiceNames],
     command_type: CommandType,
-    index_parts: bool,
     dataset_subset: Optional[DatasetTimeAndSpaceSubset],
     dataset_sync: bool,
     username: Optional[str],
 ) -> RetrievalService:
-    if len(dataset_version.parts) > 1 and dataset_sync:
-        raise Exception(
-            "Sync is not supported for datasets with multiple parts."
-        )
     if force_dataset_part_label:
         logger.info(
             f"You forced selection of dataset part "

--- a/doc/usage/get-usage.rst
+++ b/doc/usage/get-usage.rst
@@ -75,7 +75,6 @@ The ``--sync`` option downloads original files only if they do not exist or are 
 
 - ``--sync`` is not compatible with ``--no-directories``.
 - ``--sync`` only works with ``--dataset-version``. (see :ref:`dataset-version <dataset version>` option )
-- ``--sync`` functionality is not available for datasets with several parts (e.g., INSITU or static datasets).
 
 About filtering options
 ------------------------

--- a/tests/test_get_sync.py
+++ b/tests/test_get_sync.py
@@ -34,13 +34,21 @@ class TestGetSync:
             "--staging",  # TODO: staging dataset for the moment, update when needed
             "--filter",
             "*20230705_dm-metno-MODEL-topaz5*",
+            "--response-fields",
+            "all",
         ]
         self.output = execute_in_terminal(self.command)
-        assert (
-            b"cmems_mod_arc_phy_anfc_6km_detided_P1D-m_202311/"
-            b"2023/07/20230705_dm-metno-MODEL-"
-            b"topaz5-ARC-b20230710-fv02.0.nc"
-        ) in self.output.stderr
+        response_get = json.loads(self.output.stdout)
+        file_to_check = (
+            "cmems_mod_arc_phy_anfc_6km_detided_P1D-m_202311/"
+            "2023/07/20230705_dm-metno-MODEL-topaz5-ARC-b20230710-fv02.0.nc"
+        )
+        assert [
+            "found"
+            for file_get in response_get["files"]
+            if file_to_check in file_get["file_path"]
+        ]
+        assert self.output.returncode == 0
 
     def test_get_sync_works_for_dataset_with_no_default_parts(self, tmp_path):
         self.command = self.command = [
@@ -54,14 +62,23 @@ class TestGetSync:
             "-o",
             f"{tmp_path}",
             "--filter",
-            "*20241206*",
+            "*20241203/NO_TS_TG_ZwartsluisTG_20241203*",
+            "--response-fields",
+            "all",
         ]
         self.output = execute_in_terminal(self.command)
-        assert (
-            b"cmems_mod_arc_phy_anfc_6km_detided_P1D-m_202311/"
-            b"2023/07/20230705_dm-metno-MODEL-"
-            b"topaz5-ARC-b20230710-fv02.0.nc"
-        ) in self.output.stderr
+        response_get = json.loads(self.output.stdout)
+        file_to_check = (
+            "INSITU_GLO_PHYBGCWAV_DISCRETE_MYNRT_013_030/"
+            "cmems_obs-ins_glo_phybgcwav_mynrt_na_irr_202311/"
+            "latest/20241203/NO_TS_TG_ZwartsluisTG_20241203.nc"
+        )
+        assert [
+            "found"
+            for file_get in response_get["files"]
+            if file_to_check in file_get["file_path"]
+        ]
+        assert self.output.returncode == 0
 
     def test_get_sync_with_dataset_part(self, tmp_path):
         self.command = [
@@ -76,13 +93,24 @@ class TestGetSync:
             "history",
             "--filter",
             "*GL_PR_BO_3*",
+            "--response-fields",
+            "all",
             "-o",
             f"{tmp_path}",
-            "--show-outputnames",
         ]
         self.output = execute_in_terminal(self.command)
         assert self.output.returncode == 0
-        assert (b"history/BO/GL_PR_BO_3YVG.nc") in self.output.stdout
+        response_get = json.loads(self.output.stdout)
+        file_to_check = (
+            "INSITU_ARC_PHYBGCWAV_DISCRETE_MYNRT_013_031/"
+            "cmems_obs-ins_arc_phybgcwav_mynrt_na_irr_202311"
+            "/history/BO/GL_PR_BO_3YVG.nc"
+        )
+        assert [
+            "found"
+            for file_get in response_get["files"]
+            if file_to_check in file_get["file_path"]
+        ]
 
         # now there shouldn't be any files to download
         self.output = execute_in_terminal(self.command)

--- a/tests/test_get_sync.py
+++ b/tests/test_get_sync.py
@@ -20,23 +20,73 @@ class TestGetSync:
             tmp_path
         )
 
-    def test_get_sync_not_working_with_datasets_with_parts(self, tmp_path):
+    def test_get_sync_works_for_dataset_with_default_parts(self, tmp_path):
         self.command = self.command = [
             "copernicusmarine",
             "get",
             "--dataset-id",
-            "cmems_obs-ins_blk_phybgcwav_mynrt_na_irr",
+            "cmems_mod_arc_phy_anfc_6km_detided_P1D-m",
             "--sync",
             "--dataset-version",
             "202311",
             "-o",
             f"{tmp_path}",
+            "--staging",  # TODO: staging dataset for the moment, update when needed
+            "--filter",
+            "*20230705_dm-metno-MODEL-topaz5*",
         ]
         self.output = execute_in_terminal(self.command)
         assert (
-            b"Sync is not supported for datasets with multiple parts."
-            in self.output.stderr
-        )
+            b"cmems_mod_arc_phy_anfc_6km_detided_P1D-m_202311/"
+            b"2023/07/20230705_dm-metno-MODEL-"
+            b"topaz5-ARC-b20230710-fv02.0.nc"
+        ) in self.output.stderr
+
+    def test_get_sync_works_for_dataset_with_no_default_parts(self, tmp_path):
+        self.command = self.command = [
+            "copernicusmarine",
+            "get",
+            "--dataset-id",
+            "cmems_obs-ins_glo_phybgcwav_mynrt_na_irr",
+            "--sync",
+            "--dataset-version",
+            "202311",
+            "-o",
+            f"{tmp_path}",
+            "--filter",
+            "*20241206*",
+        ]
+        self.output = execute_in_terminal(self.command)
+        assert (
+            b"cmems_mod_arc_phy_anfc_6km_detided_P1D-m_202311/"
+            b"2023/07/20230705_dm-metno-MODEL-"
+            b"topaz5-ARC-b20230710-fv02.0.nc"
+        ) in self.output.stderr
+
+    def test_get_sync_with_dataset_part(self, tmp_path):
+        self.command = [
+            "copernicusmarine",
+            "get",
+            "--dataset-id",
+            "cmems_obs-ins_arc_phybgcwav_mynrt_na_irr",
+            "--sync",
+            "--dataset-version",
+            "202311",
+            "--dataset-part",
+            "history",
+            "--filter",
+            "*GL_PR_BO_3*",
+            "-o",
+            f"{tmp_path}",
+            "--show-outputnames",
+        ]
+        self.output = execute_in_terminal(self.command)
+        assert self.output.returncode == 0
+        assert (b"history/BO/GL_PR_BO_3YVG.nc") in self.output.stdout
+
+        # now there shouldn't be any files to download
+        self.output = execute_in_terminal(self.command)
+        assert b"No data to download" in self.output.stderr
 
     def test_get_sync_needs_version(self):
         self.command = [


### PR DESCRIPTION
When we have more than one part, allow still the syncing of the options. Correcting [CMT-151](https://cms-change.atlassian.net/browse/CMT-151) also for version 2 of the toolbox (and even allowing it for several parts).

Currently, the tests are done on the staging area, as in PRD the datasets have been removed for the moment. We will need to update this.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--240.org.readthedocs.build/en/240/

<!-- readthedocs-preview copernicusmarine end -->