### PR TITLE
fix: correcting issues with compression

### DIFF
--- a/copernicusmarine/command_line_interface/group_subset.py
+++ b/copernicusmarine/command_line_interface/group_subset.py
@@ -249,10 +249,10 @@ def cli_subset() -> None:
     "--netcdf-compression-level",
     type=click.IntRange(0, 9),
     is_flag=False,
-    flag_value=4,
+    flag_value=1,
     default=0,
     help=documentation_utils.SUBSET["NETCDF_COMPRESSION_LEVEL_HELP"]
-    + " If used as a flag, the assigned value will be 4.",
+    + " If used as a flag, the assigned value will be 1.",
 )
 @click.option(
     "--netcdf3-compatible",

--- a/copernicusmarine/core_functions/models.py
+++ b/copernicusmarine/core_functions/models.py
@@ -179,8 +179,8 @@ class ResponseSubset(BaseModel):
     output_directory: pathlib.Path
     #: File name.
     filename: str
-    #: Estimation of the size of the final result file in MB
-    #: (not taking into account compression).
+    #: Estimation of the size of the final result file in MB.
+    #: This estimation may not be accurate if you save the result as a compressed NetCDF file.
     file_size: Optional[float]
     #: Estimation of the maximum amount of data needed to
     #: get the final result in MB.

--- a/copernicusmarine/core_functions/models.py
+++ b/copernicusmarine/core_functions/models.py
@@ -179,7 +179,8 @@ class ResponseSubset(BaseModel):
     output_directory: pathlib.Path
     #: File name.
     filename: str
-    #: Estimation of the size of the final result file in MB.
+    #: Estimation of the size of the final result file in MB
+    #: (not taking into account compression).
     file_size: Optional[float]
     #: Estimation of the maximum amount of data needed to
     #: get the final result in MB.

--- a/copernicusmarine/core_functions/models.py
+++ b/copernicusmarine/core_functions/models.py
@@ -180,7 +180,8 @@ class ResponseSubset(BaseModel):
     #: File name.
     filename: str
     #: Estimation of the size of the final result file in MB.
-    #: This estimation may not be accurate if you save the result as a compressed NetCDF file.
+    #: This estimation may not be accurate if you save the result as
+    #: a compressed NetCDF file.
     file_size: Optional[float]
     #: Estimation of the maximum amount of data needed to
     #: get the final result in MB.

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -539,22 +539,8 @@ def _download_dataset_as_netcdf(
             shuffle=True,
         )
         keys_to_keep = {
-            "_FillValue",
-            "blosc_shuffle",
-            "chunksizes",
-            "complevel",
-            "compression",
-            "compression_opts",
-            "contiguous",
-            "dtype",
-            "endian",
-            "fletcher32",
-            "quantize_mode",
-            "shuffle",
-            "significant_digits",
-            "szip_coding",
-            "szip_pixels_per_block",
-            "zlib",
+            "scale_factor",
+            "add_offset",
         }
         encoding = {
             name: {

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -58,11 +58,11 @@ About ``--netcdf-compression-level`` options
 
 If writing data to a NetCDF file (the default format), the ``--netcdf-compression-level`` option can be set to compress the downloaded file. This reduces file size but increases writing time. Without this option, the file is written faster but with a larger size. For Zarr format ('.zarr' extension), the default compression of the Copernicus Marine Data Store is applied, making the download fast and compressed without using ``--netcdf-compression-level``.
 
-Default NetCDF compression settings for xarray:
+Default NetCDF compression settings for the toolbox are:
 
 .. code-block:: text
 
-    {'zlib': True, 'complevel': 4, 'contiguous': False, 'shuffle': True}
+    {'zlib': True, 'complevel': 1, 'contiguous': False, 'shuffle': True}
 
 Set the ``--netcdf-compression-level`` to a custom compression level between 0 (no compression, by default) and 9 (maximum compression).
 

--- a/tests/__snapshots__/test_help_command_interface.ambr
+++ b/tests/__snapshots__/test_help_command_interface.ambr
@@ -365,7 +365,7 @@
     '                                  NetCDF output file. A value of 0 means no',
     '                                  compression, and 9 is the highest level of',
     '                                  compression available. If used as a flag,',
-    '                                  the assigned value will be 4.  [0<=x<=9]',
+    '                                  the assigned value will be 1.  [0<=x<=9]',
     '  --netcdf3-compatible            Enable downloading the dataset in a netCDF3',
     '                                  compatible format.',
     '  --chunk-size-limit INTEGER RANGE',

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -1387,7 +1387,7 @@ class TestCommandLineInterface:
         size_without_option = get_file_size(filepath_without_option)
         size_with_option = get_file_size(filepath_with_option)
         logger.info(f"{size_without_option=}, {size_with_option=}")
-        assert 1.5 * size_with_option < size_without_option
+        assert 1.4 * size_with_option < size_without_option
 
     def test_omi_arco_service(self, tmp_path):
         base_command = [

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -1337,7 +1337,7 @@ class TestCommandLineInterface:
         assert dataset_without_option.uo.encoding["complevel"] == 0
 
         assert dataset_with_option.uo.encoding["zlib"] is True
-        assert dataset_with_option.uo.encoding["complevel"] == 4
+        assert dataset_with_option.uo.encoding["complevel"] == 1
         assert dataset_with_option.uo.encoding["contiguous"] is False
         assert dataset_with_option.uo.encoding["shuffle"] is True
 
@@ -1387,7 +1387,7 @@ class TestCommandLineInterface:
         size_without_option = get_file_size(filepath_without_option)
         size_with_option = get_file_size(filepath_with_option)
         logger.info(f"{size_without_option=}, {size_with_option=}")
-        assert 4 * size_with_option < size_without_option
+        assert 1.5 * size_with_option < size_without_option
 
     def test_omi_arco_service(self, tmp_path):
         base_command = [

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -306,7 +306,7 @@ class TestPythonInterface:
             netcdf_compression_level=1,
             output_filename="compressed_data.nc",
         )
-        ds1 = xarray.open_dataset(f"{tmp_path}" + "/uncompressed_data.nc")
+        dataset_uncompressed = xarray.open_dataset(f"{tmp_path}" + "/uncompressed_data.nc")
         ds2 = xarray.open_dataset(f"{tmp_path}" + "/compressed_data.nc")
         size_uncompressed = get_file_size(
             f"{tmp_path}" + "/uncompressed_data.nc"

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -312,7 +312,7 @@ class TestPythonInterface:
             f"{tmp_path}" + "/uncompressed_data.nc"
         )
         size_compressed = get_file_size(f"{tmp_path}" + "/compressed_data.nc")
-        assert size_uncompressed > 1.01 * size_compressed
+        assert size_uncompressed > 1.5 * size_compressed
         diff = ds1 - ds2
         diff.attrs = ds1.attrs
         for var in diff.data_vars:

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -19,10 +19,8 @@ from copernicusmarine.download_functions.utils import (
 )
 
 
-def get_file_size(filepath):
-    file_path = Path(filepath)
-    file_stats = file_path.stat()
-    return file_stats.st_size
+def get_file_size(file_path: Path):
+    return file_path.stat().st_size
 
 
 class TestPythonInterface:

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -307,7 +307,7 @@ class TestPythonInterface:
             output_filename="compressed_data.nc",
         )
         dataset_uncompressed = xarray.open_dataset(f"{tmp_path}" + "/uncompressed_data.nc")
-        ds2 = xarray.open_dataset(f"{tmp_path}" + "/compressed_data.nc")
+        dataset_compressed = xarray.open_dataset(f"{tmp_path}" + "/compressed_data.nc")
         size_uncompressed = get_file_size(
             f"{tmp_path}" + "/uncompressed_data.nc"
         )


### PR DESCRIPTION
Trying to solve issue [CMT-164](https://cms-change.atlassian.net/browse/CMT-164). To do that, only keep scale factor and offset but remove other types in the encoding (I think it was `type`which was causing the problems).

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--241.org.readthedocs.build/en/241/

<!-- readthedocs-preview copernicusmarine end -->