### PR TITLE
chore: solving chunk search for omi

### DIFF
--- a/copernicusmarine/download_functions/utils.py
+++ b/copernicusmarine/download_functions/utils.py
@@ -375,7 +375,9 @@ def get_number_of_chunks_for_coordinate(
     ) <= abs(
         values[index_left_minimum + 1] - requested_minimum  # type: ignore
     ):
-        chunk_of_requested_minimum = math.floor((index_left_minimum) / chunking_length)
+        chunk_of_requested_minimum = math.floor(
+            (index_left_minimum) / chunking_length
+        )
     else:
         chunk_of_requested_minimum = math.floor(
             (index_left_minimum + 1) / chunking_length
@@ -389,7 +391,9 @@ def get_number_of_chunks_for_coordinate(
         or abs(values[index_right_maximum] - requested_maximum)  # type: ignore
         <= abs(values[index_right_maximum + 1] - requested_maximum)  # type: ignore
     ):
-        chunk_of_requested_maximum = math.floor((index_right_maximum) / chunking_length)
+        chunk_of_requested_maximum = math.floor(
+            (index_right_maximum) / chunking_length
+        )
     else:
         chunk_of_requested_maximum = math.floor(
             (index_right_maximum + 1) / chunking_length

--- a/copernicusmarine/download_functions/utils.py
+++ b/copernicusmarine/download_functions/utils.py
@@ -360,6 +360,8 @@ def get_number_of_chunks_for_coordinate(
             values.append(values[-1] + step_value)  # type: ignore
     elif not values:
         return None
+    elif type(values[0]) is str:
+        return None
 
     values.sort()
     if requested_minimum is None or requested_minimum < values[0]:  # type: ignore
@@ -373,9 +375,7 @@ def get_number_of_chunks_for_coordinate(
     ) <= abs(
         values[index_left_minimum + 1] - requested_minimum  # type: ignore
     ):
-        chunk_of_requested_minimum = math.floor(
-            (index_left_minimum) / chunking_length
-        )
+        chunk_of_requested_minimum = math.floor((index_left_minimum) / chunking_length)
     else:
         chunk_of_requested_minimum = math.floor(
             (index_left_minimum + 1) / chunking_length
@@ -387,13 +387,9 @@ def get_number_of_chunks_for_coordinate(
         index_right_maximum == len(values) - 1
         or index_right_maximum == len(values)
         or abs(values[index_right_maximum] - requested_maximum)  # type: ignore
-        <= abs(
-            values[index_right_maximum + 1] - requested_maximum  # type: ignore
-        )
+        <= abs(values[index_right_maximum + 1] - requested_maximum)  # type: ignore
     ):
-        chunk_of_requested_maximum = math.floor(
-            (index_right_maximum) / chunking_length
-        )
+        chunk_of_requested_maximum = math.floor((index_right_maximum) / chunking_length)
     else:
         chunk_of_requested_maximum = math.floor(
             (index_right_maximum + 1) / chunking_length


### PR DESCRIPTION
Fixing bug [CMT-161](https://cms-change.atlassian.net/browse/CMT-161), where because the dataset is OMI, it has a values set, but those are not numbers but rather regions -> hard to estimate the size then. I just skip them, as if the values were not correctly set.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--243.org.readthedocs.build/en/243/

<!-- readthedocs-preview copernicusmarine end -->