### PR TITLE
fix: all in the encoding

### DIFF
--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -519,7 +519,6 @@ def _download_dataset_as_netcdf(
     logger.debug("Writing dataset to NetCDF")
     for coord in dataset.coords:
         dataset[coord].encoding["_FillValue"] = None
-        logger.info(f"Coordinate {coord}: {dataset[coord].encoding}")
     if netcdf_compression_level > 0:
         logger.info(
             f"NetCDF compression enabled with level {netcdf_compression_level}"
@@ -544,10 +543,6 @@ def _download_dataset_as_netcdf(
         }
     else:
         encoding = None
-
-    logger.info(dataset)
-    logger.info(dataset.longitude.attrs)
-    logger.info(encoding)
 
     xarray_download_format = "NETCDF3_CLASSIC" if netcdf3_compatible else None
     engine = "h5netcdf" if not netcdf3_compatible else "netcdf4"

--- a/copernicusmarine/download_functions/download_arco_series.py
+++ b/copernicusmarine/download_functions/download_arco_series.py
@@ -519,6 +519,7 @@ def _download_dataset_as_netcdf(
     logger.debug("Writing dataset to NetCDF")
     for coord in dataset.coords:
         dataset[coord].encoding["_FillValue"] = None
+        logger.info(f"Coordinate {coord}: {dataset[coord].encoding}")
     if netcdf_compression_level > 0:
         logger.info(
             f"NetCDF compression enabled with level {netcdf_compression_level}"
@@ -529,10 +530,7 @@ def _download_dataset_as_netcdf(
             contiguous=False,
             shuffle=True,
         )
-        keys_to_keep = {
-            "scale_factor",
-            "add_offset",
-        }
+        keys_to_keep = {"scale_factor", "add_offset", "dtype", "_FillValue"}
         encoding = {
             name: {
                 **{
@@ -546,6 +544,10 @@ def _download_dataset_as_netcdf(
         }
     else:
         encoding = None
+
+    logger.info(dataset)
+    logger.info(dataset.longitude.attrs)
+    logger.info(encoding)
 
     xarray_download_format = "NETCDF3_CLASSIC" if netcdf3_compatible else None
     engine = "h5netcdf" if not netcdf3_compatible else "netcdf4"

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -1324,7 +1324,7 @@ class TestCommandLineInterface:
         size_without_option = get_file_size(filepath_without_option)
         size_with_option = get_file_size(filepath_with_option)
         logger.info(f"{size_without_option=}, {size_with_option=}")
-        assert 1.4 * size_with_option < size_without_option
+        assert 1.7 * size_with_option < size_without_option
 
     def test_omi_arco_service(self, tmp_path):
         base_command = [

--- a/tests/test_command_line_interface.py
+++ b/tests/test_command_line_interface.py
@@ -1324,7 +1324,7 @@ class TestCommandLineInterface:
         size_without_option = get_file_size(filepath_without_option)
         size_with_option = get_file_size(filepath_with_option)
         logger.info(f"{size_without_option=}, {size_with_option=}")
-        assert 1.7 * size_with_option < size_without_option
+        assert 1.6 * size_with_option < size_without_option
 
     def test_omi_arco_service(self, tmp_path):
         base_command = [

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -308,7 +308,7 @@ class TestPythonInterface:
         )
         size_uncompressed = (tmp_path / "uncompressed_data.nc").stat().st_size
         size_compressed = (tmp_path / "compressed_data.nc").stat().st_size
-        assert size_uncompressed > 1.5 * size_compressed
+        assert size_uncompressed > 2 * size_compressed
         diff = dataset_uncompressed - dataset_compressed
         diff.attrs = dataset_uncompressed.attrs
         for var in diff.data_vars:


### PR DESCRIPTION
Okay, updating the `encoding` to contain: `add_offset, scale_factor, type and _FillValue`.

It looks like it is not breaking as I thought, so looks good. Indeed with the type, the compression seems to be a little bit improved.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--249.org.readthedocs.build/en/249/

<!-- readthedocs-preview copernicusmarine end -->