### PR TITLE
fix: error logins are now more readable and pythonic

### DIFF
--- a/copernicusmarine/core_functions/login.py
+++ b/copernicusmarine/core_functions/login.py
@@ -27,18 +27,20 @@ def login_function(
             return True
         else:
             return False
-    credentials_file = credentials_file_builder(
+    credentials_file, has_been_aborted = credentials_file_builder(
         username=username,
         password=password,
         configuration_file_directory=configuration_file_directory,
         force_overwrite=force_overwrite,
     )
+    if has_been_aborted:
+        logger.info("No configuration file have been modified.")
+        return False
     if credentials_file is not None:
         logger.info(f"Credentials file stored in {credentials_file}.")
         return True
     else:
-        logger.info(
-            "Invalid credentials. No configuration file have been modified."
-        )
+        logger.error("Invalid credentials.")
+        logger.info("No configuration file have been modified.")
         logger.info(RECOVER_YOUR_CREDENTIALS_MESSAGE)
     return False

--- a/copernicusmarine/core_functions/sessions.py
+++ b/copernicusmarine/core_functions/sessions.py
@@ -1,6 +1,6 @@
 import logging
 import ssl
-from typing import Any, List, Literal, Optional, Tuple
+from typing import Any, Literal, Optional
 
 import boto3
 import botocore
@@ -50,10 +50,10 @@ def get_ssl_context() -> Optional[ssl.SSLContext]:
 
 def get_configured_boto3_session(
     endpoint_url: str,
-    operation_type: List[Literal["ListObjects", "HeadObject", "GetObject"]],
+    operation_type: list[Literal["ListObjects", "HeadObject", "GetObject"]],
     username: Optional[str] = None,
     return_ressources: bool = False,
-) -> Tuple[Any, Any]:
+) -> tuple[Any, Any]:
     config_boto3 = botocore.config.Config(
         s3={"addressing_style": "virtual"},
         signature_version=botocore.UNSIGNED,


### PR DESCRIPTION
fix [CMT-178](https://cms-change.atlassian.net/browse/CMT-178)

Allow the login errors to be clearer especially when the user aborts when asked to confirm

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--254.org.readthedocs.build/en/254/

<!-- readthedocs-preview copernicusmarine end -->