### PR TITLE
fix: sync fails if no data to download

### DIFF
--- a/copernicusmarine/download_functions/download_original_files.py
+++ b/copernicusmarine/download_functions/download_original_files.py
@@ -235,6 +235,8 @@ def _get_files_to_delete_with_sync(
     files_information: S3FilesDescriptor,
     output_directory: pathlib.Path,
 ) -> S3FilesDescriptor:
+    if not files_information.s3_files:
+        return files_information
     product_structure = str(
         _local_path_from_s3_url(
             files_information.s3_files[0].filename_in, Path("")


### PR DESCRIPTION
fix a bug where the sync-delete would fail if not file would be found (for example with a filter that does not match) 

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--255.org.readthedocs.build/en/255/

<!-- readthedocs-preview copernicusmarine end -->