### PR TITLE
chore: trigger the binaries after the release

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -3,7 +3,6 @@ name: Create Binaries MacOS and Linux
 on:
   workflow_call:
 
-
 jobs:
   build:
     strategy:
@@ -19,25 +18,25 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: mamba-org/setup-micromamba@v1
-      with:
-        micromamba-version: '1.5.6-0'
-        micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
-        environment-file: conda_environment_binary.yaml
-        environment-name: copernicusmarine-binary
-        condarc-file: .condarc
-        cache-environment: true
-        post-cleanup: 'all'
+    # - uses: mamba-org/setup-micromamba@v1
+    #   with:
+    #     micromamba-version: '1.5.6-0'
+    #     micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
+    #     environment-file: conda_environment_binary.yaml
+    #     environment-name: copernicusmarine-binary
+    #     condarc-file: .condarc
+    #     cache-environment: true
+    #     post-cleanup: 'all'
 
     # - name: Build with PyInstaller
     #   shell: micromamba-shell {0}
     #   run: |
     #     make run-using-pyinstaller-${{ matrix.os }}
 
-    - name: Set VERSION environment variable
-      id: set-version
-      shell: micromamba-shell {0}
-      run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
+    # - name: Set VERSION environment variable
+    #   id: set-version
+    #   shell: micromamba-shell {0}
+    #   run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
 
     # - name: Upload binaries to macos or ubuntu
     #   shell: micromamba-shell {0}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -5,11 +5,11 @@ on:
     workflows: ["Check format"]
     types:
       - completed
-    branches:
-       - "main"
-       - "release/**"
-       - "pre-releases/**"
-       - "!release/v1"
+    # branches:
+    #    - "main"
+    #    - "release/**"
+    #    - "pre-releases/**"
+    #    - "!release/v1"
 
 
 jobs:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,20 +1,11 @@
 name: Create Binaries MacOS and Linux
 
 on:
-  workflow_run:
-    workflows: ["Check format"]
-    types:
-      - completed
-    # branches:
-    #    - "main"
-    #    - "release/**"
-    #    - "pre-releases/**"
-    #    - "!release/v1"
+  workflow_call:
 
 
 jobs:
   build:
-    if: github.event.workflow_run.conclusion == 'failure'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -18,38 +18,38 @@ jobs:
       with:
         fetch-depth: 0
 
-    # - uses: mamba-org/setup-micromamba@v1
-    #   with:
-    #     micromamba-version: '1.5.6-0'
-    #     micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
-    #     environment-file: conda_environment_binary.yaml
-    #     environment-name: copernicusmarine-binary
-    #     condarc-file: .condarc
-    #     cache-environment: true
-    #     post-cleanup: 'all'
+    - uses: mamba-org/setup-micromamba@v1
+      with:
+        micromamba-version: '1.5.6-0'
+        micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
+        environment-file: conda_environment_binary.yaml
+        environment-name: copernicusmarine-binary
+        condarc-file: .condarc
+        cache-environment: true
+        post-cleanup: 'all'
 
-    # - name: Build with PyInstaller
-    #   shell: micromamba-shell {0}
-    #   run: |
-    #     make run-using-pyinstaller-${{ matrix.os }}
+    - name: Build with PyInstaller
+      shell: micromamba-shell {0}
+      run: |
+        make run-using-pyinstaller-${{ matrix.os }}
 
-    # - name: Set VERSION environment variable
-    #   id: set-version
-    #   shell: micromamba-shell {0}
-    #   run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
+    - name: Set VERSION environment variable
+      id: set-version
+      shell: micromamba-shell {0}
+      run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
 
-    # - name: Upload binaries to macos or ubuntu
-    #   shell: micromamba-shell {0}
-    #   env:
-    #     GH_TOKEN: ${{ github.token }}
-    #   run: |
-    #     if [ "${{ matrix.os }}" == "macos-latest" ]; then
-    #       ARCH="macos-arm64"
-    #     elif [ "${{ matrix.os }}" == "macos-13" ]; then
-    #       ARCH="macos-x86_64"
-    #     elif [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
-    #       ARCH="linux-glibc-2.35"
-    #     elif [ "${{ matrix.os }}" == "ubuntu-20.04" ]; then
-    #       ARCH="linux-glibc-2.31"
-    #     fi
-    #       gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine_${ARCH}.cli#copernicusmarine-binary-${ARCH}-for-v${{steps.set-version.outputs.VERSION}}
+    - name: Upload binaries to macos or ubuntu
+      shell: micromamba-shell {0}
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        if [ "${{ matrix.os }}" == "macos-latest" ]; then
+          ARCH="macos-arm64"
+        elif [ "${{ matrix.os }}" == "macos-13" ]; then
+          ARCH="macos-x86_64"
+        elif [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
+          ARCH="linux-glibc-2.35"
+        elif [ "${{ matrix.os }}" == "ubuntu-20.04" ]; then
+          ARCH="linux-glibc-2.31"
+        fi
+          gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine_${ARCH}.cli#copernicusmarine-binary-${ARCH}-for-v${{steps.set-version.outputs.VERSION}}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -1,7 +1,10 @@
 name: Create Binaries MacOS and Linux
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Check format"]
+    types:
+      - completed
     branches:
        - "main"
        - "release/**"
@@ -11,7 +14,7 @@ on:
 
 jobs:
   build:
-    if: startsWith(github.event.head_commit.message, 'Copernicus Marine Release') || startsWith(github.event.head_commit.message, 'Copernicus Marine Pre-Release')
+    if: github.event.workflow_run.conclusion == 'failure'
     strategy:
       fail-fast: false
       matrix:
@@ -35,28 +38,28 @@ jobs:
         cache-environment: true
         post-cleanup: 'all'
 
-    - name: Build with PyInstaller
-      shell: micromamba-shell {0}
-      run: |
-        make run-using-pyinstaller-${{ matrix.os }}
+    # - name: Build with PyInstaller
+    #   shell: micromamba-shell {0}
+    #   run: |
+    #     make run-using-pyinstaller-${{ matrix.os }}
 
     - name: Set VERSION environment variable
       id: set-version
       shell: micromamba-shell {0}
       run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
 
-    - name: Upload binaries to macos or ubuntu
-      shell: micromamba-shell {0}
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        if [ "${{ matrix.os }}" == "macos-latest" ]; then
-          ARCH="macos-arm64"
-        elif [ "${{ matrix.os }}" == "macos-13" ]; then
-          ARCH="macos-x86_64"
-        elif [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
-          ARCH="linux-glibc-2.35"
-        elif [ "${{ matrix.os }}" == "ubuntu-20.04" ]; then
-          ARCH="linux-glibc-2.31"
-        fi
-          gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine_${ARCH}.cli#copernicusmarine-binary-${ARCH}-for-v${{steps.set-version.outputs.VERSION}}
+    # - name: Upload binaries to macos or ubuntu
+    #   shell: micromamba-shell {0}
+    #   env:
+    #     GH_TOKEN: ${{ github.token }}
+    #   run: |
+    #     if [ "${{ matrix.os }}" == "macos-latest" ]; then
+    #       ARCH="macos-arm64"
+    #     elif [ "${{ matrix.os }}" == "macos-13" ]; then
+    #       ARCH="macos-x86_64"
+    #     elif [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
+    #       ARCH="linux-glibc-2.35"
+    #     elif [ "${{ matrix.os }}" == "ubuntu-20.04" ]; then
+    #       ARCH="linux-glibc-2.31"
+    #     fi
+    #       gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine_${ARCH}.cli#copernicusmarine-binary-${ARCH}-for-v${{steps.set-version.outputs.VERSION}}

--- a/.github/workflows/binary-windows.yml
+++ b/.github/workflows/binary-windows.yml
@@ -14,29 +14,29 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: mamba-org/setup-micromamba@v1
-      with:
-        micromamba-version: '1.5.6-0'
-        micromamba-binary-path: ${{ runner.temp }}\Scripts\micromamba.exe
-        environment-file: conda_environment_binary.yaml
-        environment-name: copernicusmarine-binary
-        condarc-file: .condarc
-        cache-environment: true
-        post-cleanup: 'all'
+    # - uses: mamba-org/setup-micromamba@v1
+    #   with:
+    #     micromamba-version: '1.5.6-0'
+    #     micromamba-binary-path: ${{ runner.temp }}\Scripts\micromamba.exe
+    #     environment-file: conda_environment_binary.yaml
+    #     environment-name: copernicusmarine-binary
+    #     condarc-file: .condarc
+    #     cache-environment: true
+    #     post-cleanup: 'all'
 
-    - name: Build with PyInstaller
-      shell: bash -el {0}
-      run: |
-        make run-using-pyinstaller-windows-latest
+    # - name: Build with PyInstaller
+    #   shell: bash -el {0}
+    #   run: |
+    #     make run-using-pyinstaller-windows-latest
 
-    - name: Set VERSION environment variable
-      id: set-version
-      shell: bash -el {0}
-      run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
+    # - name: Set VERSION environment variable
+    #   id: set-version
+    #   shell: bash -el {0}
+    #   run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
 
-    - name: Upload binaries to windows
-      shell: bash -el {0}
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-          gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine.exe#copernicusmarine-binary-windows-for-v${{steps.set-version.outputs.VERSION}}
+    # - name: Upload binaries to windows
+    #   shell: bash -el {0}
+    #   env:
+    #     GH_TOKEN: ${{ github.token }}
+    #   run: |
+    #       gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine.exe#copernicusmarine-binary-windows-for-v${{steps.set-version.outputs.VERSION}}

--- a/.github/workflows/binary-windows.yml
+++ b/.github/workflows/binary-windows.yml
@@ -1,15 +1,7 @@
 name: Create Binaries Windows
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
-    branches:
-       - "main"
-       - "release/**"
-       - "pre-releases/**"
-       - "!release/v1"
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/binary-windows.yml
+++ b/.github/workflows/binary-windows.yml
@@ -14,29 +14,29 @@ jobs:
       with:
         fetch-depth: 0
 
-    # - uses: mamba-org/setup-micromamba@v1
-    #   with:
-    #     micromamba-version: '1.5.6-0'
-    #     micromamba-binary-path: ${{ runner.temp }}\Scripts\micromamba.exe
-    #     environment-file: conda_environment_binary.yaml
-    #     environment-name: copernicusmarine-binary
-    #     condarc-file: .condarc
-    #     cache-environment: true
-    #     post-cleanup: 'all'
+    - uses: mamba-org/setup-micromamba@v1
+      with:
+        micromamba-version: '1.5.6-0'
+        micromamba-binary-path: ${{ runner.temp }}\Scripts\micromamba.exe
+        environment-file: conda_environment_binary.yaml
+        environment-name: copernicusmarine-binary
+        condarc-file: .condarc
+        cache-environment: true
+        post-cleanup: 'all'
 
-    # - name: Build with PyInstaller
-    #   shell: bash -el {0}
-    #   run: |
-    #     make run-using-pyinstaller-windows-latest
+    - name: Build with PyInstaller
+      shell: bash -el {0}
+      run: |
+        make run-using-pyinstaller-windows-latest
 
-    # - name: Set VERSION environment variable
-    #   id: set-version
-    #   shell: bash -el {0}
-    #   run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
+    - name: Set VERSION environment variable
+      id: set-version
+      shell: bash -el {0}
+      run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
 
-    # - name: Upload binaries to windows
-    #   shell: bash -el {0}
-    #   env:
-    #     GH_TOKEN: ${{ github.token }}
-    #   run: |
-    #       gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine.exe#copernicusmarine-binary-windows-for-v${{steps.set-version.outputs.VERSION}}
+    - name: Upload binaries to windows
+      shell: bash -el {0}
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+          gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine.exe#copernicusmarine-binary-windows-for-v${{steps.set-version.outputs.VERSION}}

--- a/.github/workflows/binary-windows.yml
+++ b/.github/workflows/binary-windows.yml
@@ -1,16 +1,18 @@
 name: Create Binaries Windows
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
     branches:
-       - main
+       - "main"
        - "release/**"
        - "pre-releases/**"
        - "!release/v1"
 
 jobs:
   build:
-    if: startsWith(github.event.head_commit.message, 'Copernicus Marine Release') || startsWith(github.event.head_commit.message, 'Copernicus Marine Pre-Release')
     runs-on: windows-latest
     timeout-minutes: 20
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Call binaries worflow
-        uses: mercator-ocean/copernicus-marine-toolbox/.github/workflows/binaries.yml@trigger-binaries-after-the-release
+        uses: mercator-ocean/copernicus-marine-toolbox/.github/workflows/binaries.yml@main
 
       # - uses: mamba-org/setup-micromamba@v1
       #   with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    branches:
-      - "main"
-      - "release/**"
+    # branches:
+    #   - "main"
+    #   - "release/**"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,11 @@ jobs:
         run: make build-and-publish-dockerhub-image
 
   create-binaries:
-    if: ${{ always() }}
+    if: ${{ success() || failure() }}
     needs: [release-pypi-docker]
     uses: ./.github/workflows/binaries.yml
 
   create-windows-binary:
-    if: ${{ always() }}
+    if: ${{ success() || failure() }}
     needs: [release-pypi-docker]
     uses: ./.github/workflows/binary-windows.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Call binaries worflow
-        uses: ./.github/workflows/binaries.yml@main
+        uses: ./.github/workflows/binaries.yml
 
       # - uses: mamba-org/setup-micromamba@v1
       #   with:
@@ -70,10 +70,10 @@ jobs:
       #   run: sleep 30s
       #   shell: bash
 
-      # - name: Call windows binary worflow
+      # - name: Call windows binary workflow
       #   uses: .github/workflows/binary-windows.yml@main
 
-      # - name: Call binaries worflow
+      # - name: Call binaries workflow
       #   uses: .github/workflows/binaries.yml@main
 
       # - name: Build and publish Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Release
 
 on:
   push:
-    # branches:
-    #   - "main"
-    #   - "release/**"
+    branches:
+      - "main"
+      - "release/**"
 
 jobs:
   release-pypi-docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,4 +82,4 @@ jobs:
       #   run: make build-and-publish-dockerhub-image
 
   create-binaries:
-    uses: ./.github/workflows/binaries.yml@main
+    uses: ./.github/workflows/binaries.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release-pypi-docker:
-    # if: startsWith(github.event.head_commit.message, 'Copernicus Marine Release')
+    if: startsWith(github.event.head_commit.message, 'Copernicus Marine Release')
     runs-on: self-hosted
     timeout-minutes: 20
 
@@ -19,67 +19,68 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      # - uses: mamba-org/setup-micromamba@v1
-      #   with:
-      #     micromamba-version: '1.5.6-0'
-      #     micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
-      #     environment-file: conda_environment.yaml
-      #     environment-name: copernicusmarine
-      #     condarc-file: .condarc
-      #     cache-environment: true
-      #     post-cleanup: 'all'
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: '1.5.6-0'
+          micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
+          environment-file: conda_environment.yaml
+          environment-name: copernicusmarine
+          condarc-file: .condarc
+          cache-environment: true
+          post-cleanup: 'all'
 
-      # - name: Build and publish Pypi package
-      #   shell: micromamba-shell {0}
-      #   env:
-      #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      #   run: |
-      #     poetry publish --build --username __token__ --password "${PYPI_TOKEN}"
+      - name: Build and publish Pypi package
+        shell: micromamba-shell {0}
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          poetry publish --build --username __token__ --password "${PYPI_TOKEN}"
 
-      # - name: Set VERSION environment variable
-      #   id: set-version
-      #   shell: micromamba-shell {0}
-      #   run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
+      - name: Set VERSION environment variable
+        id: set-version
+        shell: micromamba-shell {0}
+        run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
 
-      # - name: Create tag
-      #   shell: micromamba-shell {0}
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     git tag v${{ steps.set-version.outputs.VERSION }}
-      #     git push origin --tags
+      - name: Create tag
+        shell: micromamba-shell {0}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git tag v${{ steps.set-version.outputs.VERSION }}
+          git push origin --tags
 
-      # - name: Create Github release
-      #   shell: micromamba-shell {0}
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: gh release create v${{ steps.set-version.outputs.VERSION }} --generate-notes
+      - name: Create Github release
+        shell: micromamba-shell {0}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create v${{ steps.set-version.outputs.VERSION }} --generate-notes
 
-      # - name: Wait for Pypi version to be available
-      #   uses: cygnetdigital/wait_for_response@v2.0.0
-      #   with:
-      #     url: 'https://pypi.org/project/copernicusmarine/${{ steps.set-version.outputs.VERSION }}/'
-      #     responseCode: '200'
-      #     timeout: 600000
-      #     interval: 5000
+      - name: Wait for Pypi version to be available
+        uses: cygnetdigital/wait_for_response@v2.0.0
+        with:
+          url: 'https://pypi.org/project/copernicusmarine/${{ steps.set-version.outputs.VERSION }}/'
+          responseCode: '200'
+          timeout: 600000
+          interval: 5000
 
-      # - name: Wait 30sec for the version to be in pip
-      #   run: sleep 30s
-      #   shell: bash
+      - name: Wait 30sec for the version to be in pip
+        run: sleep 30s
+        shell: bash
 
-      # - name: Call windows binary workflow
-      #   uses: .github/workflows/binary-windows.yml@main
-
-      # - name: Call binaries workflow
-      #   uses: .github/workflows/binaries.yml@main
-
-      # - name: Build and publish Docker image
-      #   shell: micromamba-shell {0}
-      #   env:
-      #     VERSION: ${{ steps.set-version.outputs.VERSION }}
-      #     DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      #     DOCKER_HUB_PUSH_TOKEN: ${{ secrets.DOCKER_HUB_PUSH_TOKEN }}
-      #   run: make build-and-publish-dockerhub-image
+      - name: Build and publish Docker image
+        shell: micromamba-shell {0}
+        env:
+          VERSION: ${{ steps.set-version.outputs.VERSION }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PUSH_TOKEN: ${{ secrets.DOCKER_HUB_PUSH_TOKEN }}
+        run: make build-and-publish-dockerhub-image
 
   create-binaries:
+    if: ${{ always() }}
+    needs: [release-pypi-docker]
     uses: ./.github/workflows/binaries.yml
+
+  create-windows-binary:
+    if: ${{ always() }}
+    needs: [release-pypi-docker]
+    uses: ./.github/workflows/binary-windows.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Call binaries worflow
-        uses: ./.github/workflows/binaries.yml
+        uses: mercator-ocean/copernicus-marine-toolbox/.github/workflows/binaries.yml@trigger-binaries-after-the-release
 
       # - uses: mamba-org/setup-micromamba@v1
       #   with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     #   - "release/**"
 
 jobs:
-  release:
+  release-pypi-docker:
     # if: startsWith(github.event.head_commit.message, 'Copernicus Marine Release')
     runs-on: self-hosted
     timeout-minutes: 20
@@ -18,9 +18,6 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-
-      - name: Call binaries worflow
-        uses: mercator-ocean/copernicus-marine-toolbox/.github/workflows/binaries.yml@main
 
       # - uses: mamba-org/setup-micromamba@v1
       #   with:
@@ -83,3 +80,6 @@ jobs:
       #     DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       #     DOCKER_HUB_PUSH_TOKEN: ${{ secrets.DOCKER_HUB_PUSH_TOKEN }}
       #   run: make build-and-publish-dockerhub-image
+
+  create-binaries:
+    uses: ./.github/workflows/binaries.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Call binaries worflow
-        uses: .github/workflows/binaries.yml@main
+        uses: ./.github/workflows/binaries.yml@main
 
       # - uses: mamba-org/setup-micromamba@v1
       #   with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    if: startsWith(github.event.head_commit.message, 'Copernicus Marine Release')
+    # if: startsWith(github.event.head_commit.message, 'Copernicus Marine Release')
     runs-on: self-hosted
     timeout-minutes: 20
 
@@ -19,58 +19,67 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - uses: mamba-org/setup-micromamba@v1
-        with:
-          micromamba-version: '1.5.6-0'
-          micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
-          environment-file: conda_environment.yaml
-          environment-name: copernicusmarine
-          condarc-file: .condarc
-          cache-environment: true
-          post-cleanup: 'all'
+      - name: Call binaries worflow
+        uses: .github/workflows/binaries.yml@main
 
-      - name: Build and publish Pypi package
-        shell: micromamba-shell {0}
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          poetry publish --build --username __token__ --password "${PYPI_TOKEN}"
+      # - uses: mamba-org/setup-micromamba@v1
+      #   with:
+      #     micromamba-version: '1.5.6-0'
+      #     micromamba-binary-path: ${{ runner.temp }}/bin/micromamba
+      #     environment-file: conda_environment.yaml
+      #     environment-name: copernicusmarine
+      #     condarc-file: .condarc
+      #     cache-environment: true
+      #     post-cleanup: 'all'
 
-      - name: Set VERSION environment variable
-        id: set-version
-        shell: micromamba-shell {0}
-        run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
+      # - name: Build and publish Pypi package
+      #   shell: micromamba-shell {0}
+      #   env:
+      #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      #   run: |
+      #     poetry publish --build --username __token__ --password "${PYPI_TOKEN}"
 
-      - name: Create tag
-        shell: micromamba-shell {0}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git tag v${{ steps.set-version.outputs.VERSION }}
-          git push origin --tags
+      # - name: Set VERSION environment variable
+      #   id: set-version
+      #   shell: micromamba-shell {0}
+      #   run: echo "VERSION=$(poetry version --short)" >> $GITHUB_OUTPUT
 
-      - name: Create Github release
-        shell: micromamba-shell {0}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create v${{ steps.set-version.outputs.VERSION }} --generate-notes
+      # - name: Create tag
+      #   shell: micromamba-shell {0}
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     git tag v${{ steps.set-version.outputs.VERSION }}
+      #     git push origin --tags
 
-      - name: Wait for Pypi version to be available
-        uses: cygnetdigital/wait_for_response@v2.0.0
-        with:
-          url: 'https://pypi.org/project/copernicusmarine/${{ steps.set-version.outputs.VERSION }}/'
-          responseCode: '200'
-          timeout: 600000
-          interval: 5000
+      # - name: Create Github release
+      #   shell: micromamba-shell {0}
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: gh release create v${{ steps.set-version.outputs.VERSION }} --generate-notes
 
-      - name: Wait 30sec for the version to be in pip
-        run: sleep 30s
-        shell: bash
+      # - name: Wait for Pypi version to be available
+      #   uses: cygnetdigital/wait_for_response@v2.0.0
+      #   with:
+      #     url: 'https://pypi.org/project/copernicusmarine/${{ steps.set-version.outputs.VERSION }}/'
+      #     responseCode: '200'
+      #     timeout: 600000
+      #     interval: 5000
 
-      - name: Build and publish Docker image
-        shell: micromamba-shell {0}
-        env:
-          VERSION: ${{ steps.set-version.outputs.VERSION }}
-          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-          DOCKER_HUB_PUSH_TOKEN: ${{ secrets.DOCKER_HUB_PUSH_TOKEN }}
-        run: make build-and-publish-dockerhub-image
+      # - name: Wait 30sec for the version to be in pip
+      #   run: sleep 30s
+      #   shell: bash
+
+      # - name: Call windows binary worflow
+      #   uses: .github/workflows/binary-windows.yml@main
+
+      # - name: Call binaries worflow
+      #   uses: .github/workflows/binaries.yml@main
+
+      # - name: Build and publish Docker image
+      #   shell: micromamba-shell {0}
+      #   env:
+      #     VERSION: ${{ steps.set-version.outputs.VERSION }}
+      #     DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+      #     DOCKER_HUB_PUSH_TOKEN: ${{ secrets.DOCKER_HUB_PUSH_TOKEN }}
+      #   run: make build-and-publish-dockerhub-image


### PR DESCRIPTION
We noticed the the creation of the binaries might finish before the release is done so trying to do the binaries after the release

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--264.org.readthedocs.build/en/264/

<!-- readthedocs-preview copernicusmarine end -->