### PR TITLE
Update the tests also in v2

### DIFF
--- a/tests/test_dataset_version_selection.py
+++ b/tests/test_dataset_version_selection.py
@@ -11,7 +11,7 @@ class TestDatasetVersionSelection:
             "copernicusmarine",
             "get",
             "--dataset-id",
-            "METNO-ARC-SEAICE_CONC-L4-NRT-OBS",
+            "DMI-ARC-SEAICE_TEMP-L4-NRT-OBS",
             "--dry-run",
         ]
 
@@ -24,7 +24,7 @@ class TestDatasetVersionSelection:
             "copernicusmarine",
             "get",
             "--dataset-id",
-            "METNO-ARC-SEAICE_CONC-L4-NRT-OBS",
+            "DMI-ARC-SEAICE_TEMP-L4-NRT-OBS",
             "--dataset-version",
             "default",
             "--dry-run",
@@ -48,8 +48,7 @@ class TestDatasetVersionSelection:
         assert self.output.returncode == 1
         assert (
             b"Dataset version not found: No version found "
-            b"for dataset cmems_mod_blk_wav_anfc_2.5km_PT1H-i"
-            in self.output.stderr
+            b"for dataset cmems_mod_blk_wav_anfc_2.5km_PT1H-i" in self.output.stderr
         )
 
     def test_subset_when_dataset_has_only_a_default_version(self):
@@ -57,7 +56,7 @@ class TestDatasetVersionSelection:
             "copernicusmarine",
             "subset",
             "--dataset-id",
-            "METNO-ARC-SEAICE_CONC-L4-NRT-OBS",
+            "DMI-ARC-SEAICE_TEMP-L4-NRT-OBS",
             "--variable",
             "ice_concentration",
             "--dry-run",
@@ -72,7 +71,7 @@ class TestDatasetVersionSelection:
             "copernicusmarine",
             "subset",
             "--dataset-id",
-            "METNO-ARC-SEAICE_CONC-L4-NRT-OBS",
+            "DMI-ARC-SEAICE_TEMP-L4-NRT-OBS",
             "--variable",
             "ice_concentration",
             "--dataset-version",
@@ -100,22 +99,19 @@ class TestDatasetVersionSelection:
         assert self.output.returncode == 1
         assert (
             b"Dataset version not found: No version found "
-            b"for dataset cmems_mod_blk_wav_anfc_2.5km_PT1H-i"
-            in self.output.stderr
+            b"for dataset cmems_mod_blk_wav_anfc_2.5km_PT1H-i" in self.output.stderr
         )
 
     def test_dataset_version_is_specifiable_in_python_with_get(self, caplog):
 
         copernicusmarine.get(
-            dataset_id="METNO-ARC-SEAICE_CONC-L4-NRT-OBS",
+            dataset_id="DMI-ARC-SEAICE_TEMP-L4-NRT-OBS",
             dataset_version="default",
             dry_run=True,
         )
         assert 'Selected dataset version: "default"' in caplog.text
 
-    def test_dataset_version_is_specifiable_in_python_with_subset(
-        self, caplog
-    ):
+    def test_dataset_version_is_specifiable_in_python_with_subset(self, caplog):
         copernicusmarine.subset(
             dataset_id="SST_MED_SST_L4_NRT_OBSERVATIONS_010_004_a_V2",
             variables=["analysed_sst"],

--- a/tests/test_dataset_version_selection.py
+++ b/tests/test_dataset_version_selection.py
@@ -48,7 +48,8 @@ class TestDatasetVersionSelection:
         assert self.output.returncode == 1
         assert (
             b"Dataset version not found: No version found "
-            b"for dataset cmems_mod_blk_wav_anfc_2.5km_PT1H-i" in self.output.stderr
+            b"for dataset cmems_mod_blk_wav_anfc_2.5km_PT1H-i"
+            in self.output.stderr
         )
 
     def test_subset_when_dataset_has_only_a_default_version(self):
@@ -99,7 +100,8 @@ class TestDatasetVersionSelection:
         assert self.output.returncode == 1
         assert (
             b"Dataset version not found: No version found "
-            b"for dataset cmems_mod_blk_wav_anfc_2.5km_PT1H-i" in self.output.stderr
+            b"for dataset cmems_mod_blk_wav_anfc_2.5km_PT1H-i"
+            in self.output.stderr
         )
 
     def test_dataset_version_is_specifiable_in_python_with_get(self, caplog):
@@ -111,7 +113,9 @@ class TestDatasetVersionSelection:
         )
         assert 'Selected dataset version: "default"' in caplog.text
 
-    def test_dataset_version_is_specifiable_in_python_with_subset(self, caplog):
+    def test_dataset_version_is_specifiable_in_python_with_subset(
+        self, caplog
+    ):
         copernicusmarine.subset(
             dataset_id="SST_MED_SST_L4_NRT_OBSERVATIONS_010_004_a_V2",
             variables=["analysed_sst"],


### PR DESCRIPTION
There was this dataset that was being used for the tests that just ended the double-dissemination process. I'm updating the `dataset_id` to be able to keep the tests without such dataset. The new `dataset_id` contains the specifications of the old one: to only have one version, called `default`. It looks that this was the important part and the one taken into account to change the test.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--270.org.readthedocs.build/en/270/

<!-- readthedocs-preview copernicusmarine end -->