### PR TITLE
manually add dependency deprecated when building binaries

### DIFF
--- a/.github/workflows/binary-test.yml
+++ b/.github/workflows/binary-test.yml
@@ -7,7 +7,7 @@ on:
       - "main"
       - "release/**"
       - "pre-releases/**"
-  pull_request:
+  pull_request_target:
     branches:
       - "main"
     paths:

--- a/.github/workflows/binary-test.yml
+++ b/.github/workflows/binary-test.yml
@@ -12,6 +12,7 @@ on:
       - "main"
     paths:
       - 'pyproject.toml'
+      - 'conda_environment_binary.yaml'
 
 
 

--- a/.github/workflows/binary-test.yml
+++ b/.github/workflows/binary-test.yml
@@ -7,7 +7,7 @@ on:
       - "main"
       - "release/**"
       - "pre-releases/**"
-  pull_request_target:
+  pull_request:
     branches:
       - "main"
     paths:

--- a/Makefile
+++ b/Makefile
@@ -93,11 +93,11 @@ build-and-prepare-for-binary:
 # Build with macos windows and linux
 run-using-pyinstaller-windows-latest:
 	pip install -e .
-	python -m PyInstaller --copy-metadata copernicusmarine --icon=toolbox_icon.png --copy-metadata xarray --name copernicusmarine.exe --collect-data dask --add-data "C:\Users\runneradmin\micromamba\envs\copernicusmarine-binary\Lib\site-packages\distributed\distributed.yaml;.\distributed" copernicusmarine/command_line_interface/copernicus_marine.py --onefile --copy-metadata zarr
+	python -m PyInstaller --hiddenimport deprecated --copy-metadata copernicusmarine --icon=toolbox_icon.png --copy-metadata xarray --name copernicusmarine.exe --collect-data dask --add-data "C:\Users\runneradmin\micromamba\envs\copernicusmarine-binary\Lib\site-packages\distributed\distributed.yaml;.\distributed" copernicusmarine/command_line_interface/copernicus_marine.py --onefile --copy-metadata zarr
 
 run-using-pyinstaller-macos:
 	pip install -e .
-	python -m PyInstaller --noconfirm --clean --onefile --copy-metadata xarray --name copernicusmarine_macos-${ARCH}.cli  --copy-metada pandas --collect-data dask --collect-data distributed --collect-data tzdata --copy-metadata copernicusmarine copernicusmarine/command_line_interface/copernicus_marine.py --target-architecture=${ARCH} --copy-metadata zarr
+	python -m PyInstaller --hiddenimport deprecated --noconfirm --clean --onefile --copy-metadata xarray --name copernicusmarine_macos-${ARCH}.cli  --copy-metada pandas --collect-data dask --collect-data distributed --collect-data tzdata --copy-metadata copernicusmarine copernicusmarine/command_line_interface/copernicus_marine.py --target-architecture=${ARCH} --copy-metadata zarr
 
 run-using-pyinstaller-macos-13: ARCH = x86_64
 run-using-pyinstaller-macos-13: run-using-pyinstaller-macos
@@ -113,7 +113,7 @@ run-using-pyinstaller-linux:
 	pip install deprecated
 	export LD_LIBRARY_PATH=/home/runner/micromamba/envs/copernicusmarine-binary/lib
 	echo $$LD_LIBRARY_PATH
-	python3 -m PyInstaller --collect-all tzdata --copy-metadata copernicusmarine --name copernicusmarine_${DISTRIBUTION}.cli --collect-data distributed --collect-data dask  copernicusmarine/command_line_interface/copernicus_marine.py --onefile --path /opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages --copy-metadata xarray --copy-metadata zarr
+	python3 -m PyInstaller --hiddenimport deprecated --collect-all tzdata --copy-metadata copernicusmarine --name copernicusmarine_${DISTRIBUTION}.cli --collect-data distributed --collect-data dask  copernicusmarine/command_line_interface/copernicus_marine.py --onefile --path /opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages --copy-metadata xarray --copy-metadata zarr
 	chmod +rwx /home/runner/work/copernicus-marine-toolbox/copernicus-marine-toolbox/dist/copernicusmarine_${DISTRIBUTION}.cli
 
 run-using-pyinstaller-ubuntu-22.04: DISTRIBUTION = linux-glibc-2.35

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,6 @@ run-using-pyinstaller-linux:
 	ldd --version
 	which openssl
 	openssl version -a
-	pip install deprecated
 	export LD_LIBRARY_PATH=/home/runner/micromamba/envs/copernicusmarine-binary/lib
 	echo $$LD_LIBRARY_PATH
 	python3 -m PyInstaller --hiddenimport deprecated --collect-all tzdata --copy-metadata copernicusmarine --name copernicusmarine_${DISTRIBUTION}.cli --collect-data distributed --collect-data dask  copernicusmarine/command_line_interface/copernicus_marine.py --onefile --path /opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages --copy-metadata xarray --copy-metadata zarr

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ run-using-pyinstaller-linux:
 	ldd --version
 	which openssl
 	openssl version -a
+	pip install deprecated
 	export LD_LIBRARY_PATH=/home/runner/micromamba/envs/copernicusmarine-binary/lib
 	echo $$LD_LIBRARY_PATH
 	python3 -m PyInstaller --collect-all tzdata --copy-metadata copernicusmarine --name copernicusmarine_${DISTRIBUTION}.cli --collect-data distributed --collect-data dask  copernicusmarine/command_line_interface/copernicus_marine.py --onefile --path /opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages --copy-metadata xarray --copy-metadata zarr

--- a/conda_environment_binary.yaml
+++ b/conda_environment_binary.yaml
@@ -15,4 +15,3 @@ dependencies:
     - pydantic
     - pystac
     - tqdm
-    - deprecated

--- a/conda_environment_binary.yaml
+++ b/conda_environment_binary.yaml
@@ -15,3 +15,4 @@ dependencies:
     - pydantic
     - pystac
     - tqdm
+    - deprecated


### PR DESCRIPTION
Trying to solve the latest crash with the binaries.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--274.org.readthedocs.build/en/274/

<!-- readthedocs-preview copernicusmarine end -->