### PR TITLE
Updating ubuntu runner

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-22.04, macos-13, ubuntu-20.04]
+        os: [macos-latest, ubuntu-22.04, macos-13, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 
@@ -49,7 +49,7 @@ jobs:
           ARCH="macos-x86_64"
         elif [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
           ARCH="linux-glibc-2.35"
-        elif [ "${{ matrix.os }}" == "ubuntu-20.04" ]; then
-          ARCH="linux-glibc-2.31"
+        elif [ "${{ matrix.os }}" == "ubuntu-24.04" ]; then
+          ARCH="linux-glibc-2.38"
         fi
           gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine_${ARCH}.cli#copernicusmarine-binary-${ARCH}-for-v${{steps.set-version.outputs.VERSION}}

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -50,6 +50,6 @@ jobs:
         elif [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
           ARCH="linux-glibc-2.35"
         elif [ "${{ matrix.os }}" == "ubuntu-24.04" ]; then
-          ARCH="linux-glibc-2.38"
+          ARCH="linux-glibc-2.39"
         fi
           gh release upload v${{steps.set-version.outputs.VERSION}} dist/copernicusmarine_${ARCH}.cli#copernicusmarine-binary-${ARCH}-for-v${{steps.set-version.outputs.VERSION}}

--- a/.github/workflows/binary-test.yml
+++ b/.github/workflows/binary-test.yml
@@ -13,6 +13,8 @@ on:
     paths:
       - 'pyproject.toml'
       - 'conda_environment_binary.yaml'
+      - 'tests_binaries/test_*.py'
+      - 'Makefile'
 
 
 

--- a/.github/workflows/binary-test.yml
+++ b/.github/workflows/binary-test.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-22.04, macos-13, ubuntu-20.04]
+        os: [macos-latest, ubuntu-22.04, macos-13, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ run-using-pyinstaller-linux:
 run-using-pyinstaller-ubuntu-22.04: DISTRIBUTION = linux-glibc-2.35
 run-using-pyinstaller-ubuntu-22.04: run-using-pyinstaller-linux
 
-run-using-pyinstaller-ubuntu-24.04: DISTRIBUTION = linux-glibc-2.38
+run-using-pyinstaller-ubuntu-24.04: DISTRIBUTION = linux-glibc-2.39
 run-using-pyinstaller-ubuntu-24.04: run-using-pyinstaller-linux
 
 # Tests for the binaries

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,8 @@ run-using-pyinstaller-linux:
 run-using-pyinstaller-ubuntu-22.04: DISTRIBUTION = linux-glibc-2.35
 run-using-pyinstaller-ubuntu-22.04: run-using-pyinstaller-linux
 
-run-using-pyinstaller-ubuntu-20.04: DISTRIBUTION = linux-glibc-2.31
-run-using-pyinstaller-ubuntu-20.04: run-using-pyinstaller-linux
+run-using-pyinstaller-ubuntu-24.04: DISTRIBUTION = linux-glibc-2.38
+run-using-pyinstaller-ubuntu-24.04: run-using-pyinstaller-linux
 
 # Tests for the binaries
 run-tests-binaries:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,7 +82,7 @@ rst_epilog = """
 .. |download_macos_arm64| replace:: `copernicusmarine_macos-arm64 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_macos-arm64.cli>`__
 .. |download_macos_x86| replace:: `copernicusmarine_macos-x86_64 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_macos-x86_64.cli>`__
 .. |download_linux_235| replace:: `copernicusmarine_linux <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_linux-glibc-2.35.cli>`__
-.. |download_linux_238| replace:: `copernicusmarine_linux_2.38 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_linux-glibc-2.38.cli>`__
+.. |download_linux_239| replace:: `copernicusmarine_linux_2.39 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_linux-glibc-2.39.cli>`__
 .. |download_windows| replace:: `copernicusmarine <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine.exe>`__
 """.format(
     version

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,7 +82,7 @@ rst_epilog = """
 .. |download_macos_arm64| replace:: `copernicusmarine_macos-arm64 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_macos-arm64.cli>`__
 .. |download_macos_x86| replace:: `copernicusmarine_macos-x86_64 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_macos-x86_64.cli>`__
 .. |download_linux_235| replace:: `copernicusmarine_linux <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_linux-glibc-2.35.cli>`__
-.. |download_linux_231| replace:: `copernicusmarine_linux_2.31 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_linux-glibc-2.31.cli>`__
+.. |download_linux_238| replace:: `copernicusmarine_linux_2.38 <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine_linux-glibc-2.38.cli>`__
 .. |download_windows| replace:: `copernicusmarine <https://github.com/mercator-ocean/copernicus-marine-toolbox/releases/download/v{0}/copernicusmarine.exe>`__
 """.format(
     version

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -95,7 +95,7 @@ To download directly the latest stable releases:
 - MacOS arm64: |download_macos_arm64|
 - MacOS x86_64: |download_macos_x86|
 - Linux (with glibc 2.35): |download_linux_235|
-- Linux (with glibc 2.31): |download_linux_231|
+- Linux (with glibc 2.38): |download_linux_238|
 - Windows: |download_windows|
 
 
@@ -113,7 +113,7 @@ You might have to update the permissions of the binary to be able to execute it 
 
 .. code-block:: bash
 
-    chmod +rwx copernicusmarine_linux-glibc-2.31.cli
+    chmod +rwx copernicusmarine_linux-glibc-2.35.cli
 
 And from a Windows os (cmd):
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -95,7 +95,7 @@ To download directly the latest stable releases:
 - MacOS arm64: |download_macos_arm64|
 - MacOS x86_64: |download_macos_x86|
 - Linux (with glibc 2.35): |download_linux_235|
-- Linux (with glibc 2.38): |download_linux_238|
+- Linux (with glibc 2.39): |download_linux_239|
 - Windows: |download_windows|
 
 

--- a/tests_binaries/test_basic_commands_binaries.py
+++ b/tests_binaries/test_basic_commands_binaries.py
@@ -15,6 +15,8 @@ class TestBasicCommandsBinaries:
         assert self.output.returncode == 0
         self.output = execute_in_terminal([BINARY, "subset", "-h"])
         assert self.output.returncode == 0
+        self.output = execute_in_terminal([BINARY, "login", "-h"])
+        assert self.output.returncode == 0
 
     def test_describe(self):
         command = [

--- a/tests_binaries/test_basic_commands_binaries.py
+++ b/tests_binaries/test_basic_commands_binaries.py
@@ -11,6 +11,8 @@ class TestBasicCommandsBinaries:
     def test_help(self):
         self.output = execute_in_terminal([BINARY, "describe", "--help"])
         assert self.output.returncode == 0
+        self.output = execute_in_terminal([BINARY, "get", "-h"])
+        assert self.output.returncode == 0
 
     def test_describe(self):
         command = [

--- a/tests_binaries/test_basic_commands_binaries.py
+++ b/tests_binaries/test_basic_commands_binaries.py
@@ -13,6 +13,8 @@ class TestBasicCommandsBinaries:
         assert self.output.returncode == 0
         self.output = execute_in_terminal([BINARY, "get", "-h"])
         assert self.output.returncode == 0
+        self.output = execute_in_terminal([BINARY, "subset", "-h"])
+        assert self.output.returncode == 0
 
     def test_describe(self):
         command = [


### PR DESCRIPTION
From https://github.com/actions/runner-images/issues/11101 we know we will need to update the runner.

I finally chose to just update the runner rather than just deleting it, so we keep having 2 versions for ubuntu.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--290.org.readthedocs.build/en/290/

<!-- readthedocs-preview copernicusmarine end -->