### PR TITLE
feat: update arcosparse to v0.3.0

### DIFF
--- a/copernicusmarine/download_functions/download_sparse.py
+++ b/copernicusmarine/download_functions/download_sparse.py
@@ -283,7 +283,7 @@ def _get_response_subset(
         filename=str(filename),
         file_size=None,
         data_transfer_size=None,
-        variables=[],
+        variables=variables,
         # TODO: handle thoses extents maybe opening the dataframe
         coordinates_extent=[],
         status=StatusCode.SUCCESS,

--- a/copernicusmarine/download_functions/download_sparse.py
+++ b/copernicusmarine/download_functions/download_sparse.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 import pandas as pd
 from arcosparse import (
     UserConfiguration,
-    get_platforms_names,
+    get_entities_ids,
     subset_and_return_dataframe,
     subset_and_save,
 )
@@ -143,6 +143,10 @@ def download_sparse(
         "vertical_axis": subset_request.vertical_axis,
         "user_configuration": user_configuration,
         "disable_progress_bar": disable_progress_bar,
+        "columns_rename": {
+            "entity_id": "platform_id",
+            "entity_type": "platform_type",
+        },
     }
     if subset_request.file_format == "parquet":
         kwargs["output_path"] = output_path
@@ -207,6 +211,10 @@ def read_dataframe_sparse(
         url_metadata=metadata_url,
         user_configuration=user_configuration,
         disable_progress_bar=disable_progress_bar,
+        columns_rename={
+            "entity_id": "platform_id",
+            "entity_type": "platform_type",
+        },
     )
 
 
@@ -230,7 +238,7 @@ def _get_plaform_ids_to_subset(
 ) -> list[str]:
     platforms_to_subset = []
     if platform_ids:
-        platforms_names = get_platforms_names(metadata_url, user_configuration)
+        platforms_names = get_entities_ids(metadata_url, user_configuration)
         if not platforms_names:
             raise NotEnoughPlatformMetadata()
         platforms_names_with_types: set[str] = set()

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -156,7 +156,7 @@ The Copernicus Marine Toolbox has the following dependencies:
 - `numpy <https://www.numpy.org/>`__ (1.23 or later)
 - `pydantic <https://docs.pydantic.dev/>`__ (2.9.1 or later)
 - `h5netcdf <https://h5netcdf.org>`__ (1.4.0 or later)
-- `arcosparse <https://pypi.org/project/arcosparse/>`__ (0.2.0 or later)
+- `arcosparse <https://pypi.org/project/arcosparse/>`__ (0.3.0 or later)
 
 
 The Copernicus Marine Toolbox uses the xarray library to handle the data when using the ``subset`` command in the majority of cases.

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -88,11 +88,11 @@ The output will contain the following columns:
 - ``time``: The timestamp of the measurement in seconds
 - ``longitude``: The longitude of the measurement in degrees.
 - ``latitude``: The latitude of the measurement in degrees.
+- ``depth`` or ``elevation``: The depth of the measurement in meters. Or 'elevation' if selected with the ``vertical-axis`` option.
 - ``is_approx_elevation``: TBD.
 - ``value``: The value of the measurement.
 - ``value_qc``: The quality control of the value.
 - ``variable``: The variable name.
-- ``depth`` or ``elevation``: The depth of the measurement in meters. Or 'elevation' if selected with the ``vertical-axis`` option.
 
 
 These datasets have specific options and outputs:

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -90,9 +90,12 @@ The output will contain the following columns:
 - ``latitude``: The latitude of the measurement in degrees.
 - ``depth`` or ``elevation``: The depth of the measurement in meters. Or 'elevation' if selected with the ``vertical-axis`` option.
 - ``is_approx_elevation``: TBD.
+- ``pressure``: TBD.
 - ``value``: The value of the measurement.
 - ``value_qc``: The quality control of the value.
 - ``variable``: The variable name.
+
+If one of the columns would be all NaN, it will be removed from the output.
 
 
 These datasets have specific options and outputs:

--- a/poetry.lock
+++ b/poetry.lock
@@ -28,15 +28,15 @@ files = [
 
 [[package]]
 name = "arcosparse"
-version = "0.2.0"
+version = "0.3.0"
 description = "Helper to download and subset sparse data that has been Arcoified and are available through STAC and sqlite formated data"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "arcosparse-0.2.0-py3-none-any.whl", hash = "sha256:3b08ef66f93316f441d8b206828715f8b30017881224ade446f43627fe92e195"},
-    {file = "arcosparse-0.2.0.tar.gz", hash = "sha256:72471e1f80b62f169dd05f5ffbadeba54788f6f2de4b9530041408575bf5737c"},
+    {file = "arcosparse-0.3.0-py3-none-any.whl", hash = "sha256:ea17f231b0e7ec3703dd63c952347f4c9ef026ab6245b3d60da941e78f805feb"},
+    {file = "arcosparse-0.3.0.tar.gz", hash = "sha256:6b6eb4e2631fbd49f8fb6fe3b85b67cdf197f7f98fccdcb744fef26e7b423462"},
 ]
 
 [package.dependencies]
@@ -2464,4 +2464,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "20f6639efafac6e49905c5dd1be85769130094232e6d7d533d2bbcb8d8f2a3f5"
+content-hash = "2fd4ecba718e963f6774b229a27c7d553bb321e5c0ab53be1ac69695c5f0a8c7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ lxml = ">=4.9.0"
 numpy = ">=1.23.0"
 pydantic = "^2.9.1"
 h5netcdf = "^1.4.0"
-arcosparse = "^0.2.0"
+arcosparse = "^0.3.0"
 
 [project.scripts]
 copernicusmarine = 'copernicusmarine.command_line_interface.copernicus_marine:command_line_interface'

--- a/tests/__snapshots__/test_dependencies_updates.ambr
+++ b/tests/__snapshots__/test_dependencies_updates.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestDependeciesUpdates.test_update_dependencies
   dict({
-    'arcosparse': '^0.2.0',
+    'arcosparse': '^0.3.0',
     'boto3': '>=1.26',
     'click': '>=8.0.4',
     'dask': '>=2022',

--- a/tests/test_sparse_subset.py
+++ b/tests/test_sparse_subset.py
@@ -1,5 +1,7 @@
 from json import loads
 
+import pandas as pd
+
 from copernicusmarine import read_dataframe
 from tests.test_utils import execute_in_terminal
 
@@ -48,6 +50,19 @@ BASIC_COMMAND_DICT = {
     "end_datetime": "2023-11-26T03:00:00",
 }
 
+EXPECTED_COLUMNS = [
+    "platform_id",
+    "platform_type",
+    "time",
+    "longitude",
+    "latitude",
+    "depth",
+    "is_approx_elevation",
+    "value",
+    "value_qc",
+    "variable",
+]
+
 
 class TestSparseSubset:
     def test_I_can_subset_sparse_data(self, tmp_path):
@@ -62,6 +77,9 @@ class TestSparseSubset:
         response = loads(self.output.stdout)
         filename = response["filename"]
         assert (tmp_path / filename).exists()
+        df = pd.read_csv(tmp_path / filename)
+        assert not df.empty
+        assert all(column in df.columns for column in EXPECTED_COLUMNS)
 
     def test_I_can_subset_on_platform_ids_in_parquet(self, tmp_path):
         command = BASIC_COMMAND + [


### PR DESCRIPTION
Rename correctly the columns

Refactor the code not to repeat it.

Also decided to have the parquet as only one file and loaded in memory to simplify the result the user receives

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--300.org.readthedocs.build/en/300/

<!-- readthedocs-preview copernicusmarine end -->