### PR TITLE
[fix] improve naming of stereo datasets

### DIFF
--- a/copernicusmarine/download_functions/download_zarr.py
+++ b/copernicusmarine/download_functions/download_zarr.py
@@ -137,6 +137,7 @@ def download_dataset(
         dataset_id,
         file_format,
         axis_coordinate_id_mapping,
+        geographical_parameters,
     )
     output_path = pathlib.Path(output_directory, filename)
     final_result_size_estimation = get_approximation_size_final_result(

--- a/copernicusmarine/download_functions/utils.py
+++ b/copernicusmarine/download_functions/utils.py
@@ -47,6 +47,7 @@ def get_filename(
     dataset_id: str,
     file_format: FileFormat,
     axis_coordinate_id_mapping: dict[str, str],
+    geographical_parameters: GeographicalParameters,
 ) -> str:
     if filename:
         if pathlib.Path(filename).suffix in DEFAULT_FILE_EXTENSIONS:
@@ -55,7 +56,11 @@ def get_filename(
             return filename + get_file_extension(file_format)
     else:
         return _build_filename_from_dataset(
-            dataset, dataset_id, file_format, axis_coordinate_id_mapping
+            dataset,
+            dataset_id,
+            file_format,
+            axis_coordinate_id_mapping,
+            geographical_parameters,
         )
 
 
@@ -64,6 +69,7 @@ def _build_filename_from_dataset(
     dataset_id: str,
     file_format: FileFormat,
     axis_coordinate_id_mapping: dict[str, str],
+    geographical_parameters: GeographicalParameters,
 ) -> str:
     dataset_variables = "-".join(
         [str(variable_name) for variable_name in dataset.data_vars]
@@ -75,30 +81,30 @@ def _build_filename_from_dataset(
     )
     longitudes = None
     if "x" in axis_coordinate_id_mapping:
-        if axis_coordinate_id_mapping["x"] == "longitude":
+        if geographical_parameters.projection == "lonlat":
             longitudes = _format_longitudes(
                 _get_min_coordinate(dataset, axis_coordinate_id_mapping["x"]),
                 _get_max_coordinate(dataset, axis_coordinate_id_mapping["x"]),
             )
-        if axis_coordinate_id_mapping["x"] == "x":
+        if geographical_parameters.projection == "originalGrid":
             longitudes = _format_xy_axis(
                 _get_min_coordinate(dataset, axis_coordinate_id_mapping["x"]),
                 _get_max_coordinate(dataset, axis_coordinate_id_mapping["x"]),
-                axis_coordinate_id_mapping["x"],
+                "x",
             )
 
     latitudes = None
     if "y" in axis_coordinate_id_mapping:
-        if axis_coordinate_id_mapping["y"] == "latitude":
+        if geographical_parameters.projection == "lonlat":
             latitudes = _format_latitudes(
                 _get_min_coordinate(dataset, axis_coordinate_id_mapping["y"]),
                 _get_max_coordinate(dataset, axis_coordinate_id_mapping["y"]),
             )
-        if axis_coordinate_id_mapping["y"] == "y":
+        if geographical_parameters.projection == "originalGrid":
             latitudes = _format_xy_axis(
                 _get_min_coordinate(dataset, axis_coordinate_id_mapping["y"]),
                 _get_max_coordinate(dataset, axis_coordinate_id_mapping["y"]),
-                axis_coordinate_id_mapping["y"],
+                "y",
             )
 
     depths = None

--- a/copernicusmarine/download_functions/utils.py
+++ b/copernicusmarine/download_functions/utils.py
@@ -108,7 +108,6 @@ def _build_filename_from_dataset(
             )
 
     depths = None
-    logger.info(axis_coordinate_id_mapping["z"])
     if "z" in axis_coordinate_id_mapping:
         depths = _format_depths(
             _get_min_coordinate(dataset, axis_coordinate_id_mapping["z"]),

--- a/copernicusmarine/download_functions/utils.py
+++ b/copernicusmarine/download_functions/utils.py
@@ -108,12 +108,12 @@ def _build_filename_from_dataset(
             )
 
     depths = None
+    logger.info(axis_coordinate_id_mapping["z"])
     if "z" in axis_coordinate_id_mapping:
-        if axis_coordinate_id_mapping["z"] == "depth":
-            depths = _format_depths(
-                _get_min_coordinate(dataset, axis_coordinate_id_mapping["x"]),
-                _get_max_coordinate(dataset, axis_coordinate_id_mapping["x"]),
-            )
+        depths = _format_depths(
+            _get_min_coordinate(dataset, axis_coordinate_id_mapping["z"]),
+            _get_max_coordinate(dataset, axis_coordinate_id_mapping["z"]),
+        )
 
     datetimes = None
     if "t" in axis_coordinate_id_mapping:
@@ -320,9 +320,11 @@ def _format_depths(
         return ""
     else:
         if minimum_depth == maximum_depth:
-            depth = f"{abs(minimum_depth):.2f}m"
+            depth = f"{(minimum_depth):.2f}m"
+        elif minimum_depth > 0:
+            depth = f"{(minimum_depth):.2f}_{(maximum_depth):.2f}m"
         else:
-            depth = f"{abs(minimum_depth):.2f}-{abs(maximum_depth):.2f}m"
+            depth = f"{(maximum_depth):.2f}_{(minimum_depth):.2f}m"
         return depth
 
 


### PR DESCRIPTION
We recently added datasets with 'yc' and 'xc' components, and after checking the naming I corrected them. Now, for example:

`copernicusmarine subset --dry-run --dataset-part originalGrid -t 2021 -i cmems_obs-si_arc_physic_nrt_1km-grl_P1D-irr`

Outputs this filename:

`cmems_obs-si_arc_physic_nrt_1km-grl_P1D-irr_multi-vars_-923125.69x_1307874.25X_-3846677.75y_-529677.75Y_2021-01-01-2025-03-27.nc`

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--301.org.readthedocs.build/en/301/

<!-- readthedocs-preview copernicusmarine end -->