### PR TITLE
Some typos and inconsistencies are corrected , it

### DIFF
--- a/doc/usage/stereo_subset.ipynb
+++ b/doc/usage/stereo_subset.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The \"plate carrée\" projection (equirectangular projection centered on 0) is widely used. It uses simply x=longitude and y=latitude on a map. However, for regions near the poles - such as the Arctic and Antarctic - alternative coordinate systems, including the stereographic projection, are often employed. The specific projection applied to each dataset is detailed in the respective product documentation, available through the [Copernicus Marine Data Store](https://data.marine.copernicus.eu/products) (**e.g.** [this product description](https://data.marine.copernicus.eu/product/ARCTIC_ANALYSISFORECAST_PHY_002_001/description)).\n",
+    "The \"plate carrée\" projection (equirectangular projection centered on the Equator) is widely used. It uses simply x=longitude and y=latitude on a map. However, for regions near the poles - such as the Arctic and Antarctic - alternative coordinate systems, including the stereographic projection, are often employed. The specific projection applied to each dataset is detailed in the respective product documentation, available through the [Copernicus Marine Data Store](https://data.marine.copernicus.eu/products) (**e.g.** [this product description](https://data.marine.copernicus.eu/product/ARCTIC_ANALYSISFORECAST_PHY_002_001/description)).\n",
     "\n",
     "Maintaining data in the original-grid format, rather than only providing longitude and latitude coordinates, offers significant benefits:\n",
     "- It preserves the dataset's original structure and integrity\n",
@@ -32,14 +32,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Different Coordinate System -> Different Options"
+    "### Different Coordinate Systems Have Different Bounding Options"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most datasets utilize a longitude/latitude projection system. For area subsetting, the standard parameters are `minimum_longitude`, `maximum_longitude`, `minimum_latitude` and `maximum_latitude`.\n",
+    "Most datasets use a longitude/latitude projection system. For area subsetting, the standard parameters are `minimum_longitude`, `maximum_longitude`, `minimum_latitude` and `maximum_latitude`.\n",
     "\n",
     "When working with the original-grid coordinate system, the subsetting parameters differ:\n",
     "- For the x-axis: `minimum_x` (or `--minimum-x`) and  `maximum_x` (or `--maximum-x`).\n",
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Different Coordinate System -> Different Part"
+    "### Different Coordinate Systems Belong to Different Parts"
    ]
   },
   {
@@ -61,7 +61,7 @@
    "source": [
     "For a given dataset and version, the data in stereographic projection is in a different part.\n",
     "\n",
-    "Consequently, when downloading data in their original-grid, you must explicitly specify the dataset part:\n",
+    "Consequently, when downloading data in their Original-grid, you must explicitly specify the dataset part:\n",
     "\n",
     "- Command-line interface: Use ``--dataset-part originalGrid``\n",
     "- Python interface: Specify ``dataset_part=\"originalGrid\"``\n",
@@ -913,7 +913,7 @@
     "- Spatial boundaries are defined onto the stereographic grid (``minimum_x``, ``maximum_x``, ``minimum_y``, ``maximum_y``) rather than the geographical one (``minimum_longitude``, ``minimum_latitude``, etc.)\n",
     "- The dataset part must be explicitly specified as ``\"originalGrid\"`` (as previously documented)\n",
     "\n",
-    "The data retrieval with original-grid projection is performed as follows:"
+    "The data retrieval with Original-grid projection is performed as follows:"
    ]
   },
   {
@@ -1908,7 +1908,7 @@
    "source": [
     "## CLI Options, Shortcuts and Behaviour\n",
     "\n",
-    "As with all toolbox functionality, you may alternatively use the command-line interface (CLI) to retrieve data in original-grid projections. This requires careful specification of both the coordinate parameters and the correct dataset part parameter."
+    "As with all toolbox functionality, you may alternatively use the command-line interface (CLI) to retrieve data in Original-grid projections. This requires careful specification of both the correct coordinate bounds option and the correct dataset part."
    ]
   },
   {
@@ -1932,11 +1932,11 @@
    "source": [
     "**Original-Grid Projection Requirements:**\n",
     "\n",
-    "For stereographic or other original-grid projections, you must:\n",
+    "For stereographic or other Original-grid projections, you must:\n",
     "\n",
     "- Explicitly declare ``--dataset-part originalGrid``\n",
     "- Use projected coordinates (e.g., `--maximum-x`) instead of geographic coordinates\n",
-    "- Ensure coordinate values match the dataset's native projection\n",
+    "- Ensure coordinate values are within the dataset value range\n",
     "\n",
     "```bash\n",
     "copernicusmarine subset -i cmems_mod_arc_bgc_my_ecosmo_P1D-m -v chl -v zooc -v o2 --minimum-y -5 --maximum-y 5 --minimum-x -10 --maximum-x 10 --dry-run --dataset-part originalGrid\n",
@@ -1966,7 +1966,7 @@
    "source": [
     "**Geographic Coordinates (Degrees):**\n",
     "\n",
-    "Without the originalGrid specification, the same shortcuts default to degree units:\n",
+    "Without the originalGrid part specification, the same shortcuts default to degree units:\n",
     "\n",
     "```bash\n",
     "copernicusmarine subset -i cmems_mod_arc_bgc_my_ecosmo_P1D-m -v chl -v zooc -v o2 -y 65 -Y 85 -x -180 -X 180 --dry-run\n",
@@ -2017,7 +2017,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## List of datasets that have original-grid projection"
+    "## List of datasets that have Original-grid projection"
    ]
   },
   {
@@ -2059,7 +2059,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -2073,7 +2073,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
was mostly about the use of plural and the
"Original-grid" word

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--313.org.readthedocs.build/en/313/

<!-- readthedocs-preview copernicusmarine end -->