### PR TITLE
Correct documentation typos for the spare and stereographic subsetting

### DIFF
--- a/copernicusmarine/catalogue_parser/models.py
+++ b/copernicusmarine/catalogue_parser/models.py
@@ -494,7 +494,7 @@ class CopernicusMarinePart(BaseModel):
         ],
     ]:
         """
-        Get the coordinates of the part as a dicty.
+        Get the coordinates of the part as a dict.
         The dict has the coordinate IDs as keys and the values are tuples of:
 
         - the coordinate

--- a/copernicusmarine/catalogue_parser/models.py
+++ b/copernicusmarine/catalogue_parser/models.py
@@ -494,21 +494,21 @@ class CopernicusMarinePart(BaseModel):
         ],
     ]:
         """
-        Get the coordinates of the part as a dict.
-        The dict has the coordinate ids as keys and the values are tuples of:
+        Get the coordinates of the part as a dictionary.
+        The dictionary has the coordinate IDs as keys and the values are tuples of:
 
         - the coordinate
-        - variable_ids: list of variable the coordinate is associated with
+        - variable_ids: list of variables the coordinate is associated with
         - service_names: list of service names the coordinate is associated with
 
         Parameters
         ----------
-        service : CopernicusMarinePart
-            The service to get the coordinates
+        service (optional) : CopernicusMarinePart
+            The service whose coordinates we want to retrieve
 
         Returns
         -------
-        dict
+        dictionary
             The coordinates of the part and the associated variables and services
         """
         coordinates = {}

--- a/copernicusmarine/catalogue_parser/models.py
+++ b/copernicusmarine/catalogue_parser/models.py
@@ -73,7 +73,7 @@ def _service_type_from_web_api_string(
         OMI_ARCO = "omi"
         STATIC_ARCO = "static"
 
-    web_api_mapping: t[WebApi, CopernicusMarineServiceNames] = {
+    web_api_mapping: dict[WebApi, CopernicusMarineServiceNames] = {
         WebApi.GEOSERIES: CopernicusMarineServiceNames.GEOSERIES,
         WebApi.TIMESERIES: CopernicusMarineServiceNames.TIMESERIES,
         WebApi.PLATFORMSERIES: CopernicusMarineServiceNames.PLATFORMSERIES,
@@ -152,10 +152,10 @@ class CopernicusMarineCoordinate(BaseModel):
         cls: Type[Coordinate],
         variable_id: str,
         dimension: str,
-        dimension_metadata: t,
+        dimension_metadata: dict,
         arco_data_metadata_producer_valid_start_date: Optional[str],
         arco_data_metadata_producer_valid_start_index: Optional[int],
-        cube_dimensions: t,
+        cube_dimensions: dict,
     ) -> Coordinate:
         coordinates_info = dimension_metadata.get("coords", {})
         minimum_value = None

--- a/copernicusmarine/catalogue_parser/models.py
+++ b/copernicusmarine/catalogue_parser/models.py
@@ -494,8 +494,8 @@ class CopernicusMarinePart(BaseModel):
         ],
     ]:
         """
-        Get the coordinates of the part as a dictionary.
-        The dictionary has the coordinate IDs as keys and the values are tuples of:
+        Get the coordinates of the part as a dicty.
+        The dict has the coordinate IDs as keys and the values are tuples of:
 
         - the coordinate
         - variable_ids: list of variables the coordinate is associated with
@@ -503,8 +503,7 @@ class CopernicusMarinePart(BaseModel):
 
         Parameters
         ----------
-        service (optional) : CopernicusMarinePart
-            The service whose coordinates we want to retrieve
+        None
 
         Returns
         -------

--- a/copernicusmarine/catalogue_parser/models.py
+++ b/copernicusmarine/catalogue_parser/models.py
@@ -73,7 +73,7 @@ def _service_type_from_web_api_string(
         OMI_ARCO = "omi"
         STATIC_ARCO = "static"
 
-    web_api_mapping: dict[WebApi, CopernicusMarineServiceNames] = {
+    web_api_mapping: t[WebApi, CopernicusMarineServiceNames] = {
         WebApi.GEOSERIES: CopernicusMarineServiceNames.GEOSERIES,
         WebApi.TIMESERIES: CopernicusMarineServiceNames.TIMESERIES,
         WebApi.PLATFORMSERIES: CopernicusMarineServiceNames.PLATFORMSERIES,
@@ -152,10 +152,10 @@ class CopernicusMarineCoordinate(BaseModel):
         cls: Type[Coordinate],
         variable_id: str,
         dimension: str,
-        dimension_metadata: dict,
+        dimension_metadata: t,
         arco_data_metadata_producer_valid_start_date: Optional[str],
         arco_data_metadata_producer_valid_start_index: Optional[int],
-        cube_dimensions: dict,
+        cube_dimensions: t,
     ) -> Coordinate:
         coordinates_info = dimension_metadata.get("coords", {})
         minimum_value = None
@@ -501,13 +501,9 @@ class CopernicusMarinePart(BaseModel):
         - variable_ids: list of variables the coordinate is associated with
         - service_names: list of service names the coordinate is associated with
 
-        Parameters
-        ----------
-        None
-
         Returns
         -------
-        dictionary
+        dict
             The coordinates of the part and the associated variables and services
         """
         coordinates = {}

--- a/doc/usage/describe-usage.rst
+++ b/doc/usage/describe-usage.rst
@@ -221,16 +221,16 @@ It allows in some cases to access the metadata of datasets that are to be releas
 ``arco_updating_start_date`` and ``arco_updated_date`` fields
 ---------------------------------------------------------------
 
-These fields on the :class:`copernicusmarine.CopernicusMarinePart` can help to know if when the requested data has been updated and if it is still being updated.
-It only concerns the ARCO services i.e. all services for the subsetting. It is not meant to indicate when the original data has been updated.
+These fields on the :class:`copernicusmarine.CopernicusMarinePart` can help to determine when the requested data has been updated on the Marine Data Store and if it is currently being updated.
+It only concerns the ARCO services i.e. all services for the subsetting. They are not meant to indicate when the data producers last updated the original data.
 
-``arco_updated_date`` is the date when the ARCO data has been updated for the last time.
-For example, if ``arco_updated_date=="2025-03-26T08:50:15.873Z"`` it means that the last update of the dataset was on the 26th of March 2025.
+``arco_updated_date`` is the date when the ARCO data was last updated.
+For example, if ``arco_updated_date=="2025-03-26T08:50:15.873Z"``, it means that the last update of the dataset was on the 26th of March 2025.
 
-``arco_updating_start_date`` is the time point of the dataset from which the data is being updated.
-For example, if ``arco_updating_start_date=="1990-05-16T08:50:15.873Z"`` it means that the dataset is being updated from the time point: 16th of May 1990.
+``arco_updating_start_date`` refers to the segment of the data currently being updated. The datasets are updated by temporal segments, starting from a certain date and continuing to the end of the dataset. This value marks the start of the temporal segment being updated.
+For example, if ``arco_updating_start_date=="1990-05-16T08:50:15.873Z"`` it means that the dataset is being updated starting from the 16th of May 1990.
 See `the raise-if-updating <raise-if-updating>`_ option to be sure your requested data is up-to-date.
 
 .. warning::
 
-    ``arco_updating_start_date`` is a date that designate a value in the dataset contrary to ``arco_updated_date`` which is a "real life" date.
+    ``arco_updating_start_date`` is a date within the dataset while ``arco_updated_date`` is a real-world timestamp.

--- a/doc/usage/stereo_subset.ipynb
+++ b/doc/usage/stereo_subset.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The \"plate carrée\" projection (equirectangular projection centered on 0) is widely used. It uses simply x=longitude and y=latitude on a map. However, for regions near the poles - such as the Arctic and Antarctic - alternative coordinate systems, including the stereographic projection, are often employed. The specific projection applied to each dataset is detailed in the respective product documentation, available through the [Copernicus Marine Data Store](https://data.marine.copernicus.eu/products) (**e.g.** [this product description](https://data.marine.copernicus.eu/product/ARCTIC_ANALYSISFORECAST_PHY_002_001/description)).\n",
+    "The \"plate carrée\" projection (equirectangular projection centered on the Equator) is widely used. It uses simply x=longitude and y=latitude on a map. However, for regions near the poles - such as the Arctic and Antarctic - alternative coordinate systems, including the stereographic projection, are often employed. The specific projection applied to each dataset is detailed in the respective product documentation, available through the [Copernicus Marine Data Store](https://data.marine.copernicus.eu/products) (**e.g.** [this product description](https://data.marine.copernicus.eu/product/ARCTIC_ANALYSISFORECAST_PHY_002_001/description)).\n",
     "\n",
     "Maintaining data in the original-grid format, rather than only providing longitude and latitude coordinates, offers significant benefits:\n",
     "- It preserves the dataset's original structure and integrity\n",
@@ -32,14 +32,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Different Coordinate System -> Different Options"
+    "### Different Coordinate Systems Have Different Bounding Options"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most datasets utilize a longitude/latitude projection system. For area subsetting, the standard parameters are `minimum_longitude`, `maximum_longitude`, `minimum_latitude` and `maximum_latitude`.\n",
+    "Most datasets use a longitude/latitude projection system. For area subsetting, the standard parameters are `minimum_longitude`, `maximum_longitude`, `minimum_latitude` and `maximum_latitude`.\n",
     "\n",
     "When working with the original-grid coordinate system, the subsetting parameters differ:\n",
     "- For the x-axis: `minimum_x` (or `--minimum-x`) and  `maximum_x` (or `--maximum-x`).\n",
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Different Coordinate System -> Different Part"
+    "### Different Coordinate Systems Belong to Different Parts"
    ]
   },
   {
@@ -61,7 +61,7 @@
    "source": [
     "For a given dataset and version, the data in stereographic projection is in a different part.\n",
     "\n",
-    "Consequently, when downloading data in their original-grid, you must explicitly specify the dataset part:\n",
+    "Consequently, when downloading data in their Original-grid, you must explicitly specify the dataset part:\n",
     "\n",
     "- Command-line interface: Use ``--dataset-part originalGrid``\n",
     "- Python interface: Specify ``dataset_part=\"originalGrid\"``\n",
@@ -913,7 +913,7 @@
     "- Spatial boundaries are defined onto the stereographic grid (``minimum_x``, ``maximum_x``, ``minimum_y``, ``maximum_y``) rather than the geographical one (``minimum_longitude``, ``minimum_latitude``, etc.)\n",
     "- The dataset part must be explicitly specified as ``\"originalGrid\"`` (as previously documented)\n",
     "\n",
-    "The data retrieval with original-grid projection is performed as follows:"
+    "The data retrieval with Original-grid projection is performed as follows:"
    ]
   },
   {
@@ -1908,7 +1908,7 @@
    "source": [
     "## CLI Options, Shortcuts and Behaviour\n",
     "\n",
-    "As with all toolbox functionality, you may alternatively use the command-line interface (CLI) to retrieve data in original-grid projections. This requires careful specification of both the coordinate parameters and the correct dataset part parameter."
+    "As with all toolbox functionality, you may alternatively use the command-line interface (CLI) to retrieve data in Original-grid projections. This requires careful specification of both the correct coordinate bounds option and the correct dataset part."
    ]
   },
   {
@@ -1932,11 +1932,11 @@
    "source": [
     "**Original-Grid Projection Requirements:**\n",
     "\n",
-    "For stereographic or other original-grid projections, you must:\n",
+    "For stereographic or other Original-grid projections, you must:\n",
     "\n",
     "- Explicitly declare ``--dataset-part originalGrid``\n",
     "- Use projected coordinates (e.g., `--maximum-x`) instead of geographic coordinates\n",
-    "- Ensure coordinate values match the dataset's native projection\n",
+    "- Ensure coordinate values are within the dataset value range\n",
     "\n",
     "```bash\n",
     "copernicusmarine subset -i cmems_mod_arc_bgc_my_ecosmo_P1D-m -v chl -v zooc -v o2 --minimum-y -5 --maximum-y 5 --minimum-x -10 --maximum-x 10 --dry-run --dataset-part originalGrid\n",
@@ -1966,7 +1966,7 @@
    "source": [
     "**Geographic Coordinates (Degrees):**\n",
     "\n",
-    "Without the originalGrid specification, the same shortcuts default to degree units:\n",
+    "Without the originalGrid part specification, the same shortcuts default to degree units:\n",
     "\n",
     "```bash\n",
     "copernicusmarine subset -i cmems_mod_arc_bgc_my_ecosmo_P1D-m -v chl -v zooc -v o2 -y 65 -Y 85 -x -180 -X 180 --dry-run\n",
@@ -2017,7 +2017,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## List of datasets that have original-grid projection"
+    "## List of datasets that have Original-grid projection"
    ]
   },
   {
@@ -2059,7 +2059,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -2073,7 +2073,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/doc/usage/stereo_subset.ipynb
+++ b/doc/usage/stereo_subset.ipynb
@@ -14,9 +14,9 @@
    "source": [
     "The \"plate carrée\" projection (equirectangular projection centered on the Equator) is widely used. It uses simply x=longitude and y=latitude on a map. However, for regions near the poles - such as the Arctic and Antarctic - alternative coordinate systems, including the stereographic projection, are often employed. The specific projection applied to each dataset is detailed in the respective product documentation, available through the [Copernicus Marine Data Store](https://data.marine.copernicus.eu/products) (**e.g.** [this product description](https://data.marine.copernicus.eu/product/ARCTIC_ANALYSISFORECAST_PHY_002_001/description)).\n",
     "\n",
-    "Maintaining data in the original-grid format, rather than only providing longitude and latitude coordinates, offers significant benefits:\n",
+    "Maintaining data in the Original-grid format, rather than only providing longitude and latitude coordinates, offers significant benefits:\n",
     "- It preserves the dataset's original structure and integrity\n",
-    "- It facilitates direct use of the original-grid coordinates for relevant applications\n",
+    "- It facilitates direct use of the Original-grid coordinates for relevant applications\n",
     "\n",
     "We present in this notebook how to subset those data using the Copernicus Marine Toolbox."
    ]
@@ -41,11 +41,11 @@
    "source": [
     "Most datasets use a longitude/latitude projection system. For area subsetting, the standard parameters are `minimum_longitude`, `maximum_longitude`, `minimum_latitude` and `maximum_latitude`.\n",
     "\n",
-    "When working with the original-grid coordinate system, the subsetting parameters differ:\n",
+    "When working with the Original-grid coordinate system, the subsetting parameters differ:\n",
     "- For the x-axis: `minimum_x` (or `--minimum-x`) and  `maximum_x` (or `--maximum-x`).\n",
     "- For the y-axis: `minimum_y` (or `--minimum-y`) and `maximum_y` (or `--maximum-y`). \n",
     "\n",
-    "These parameters enable subsetting operations based on the original-grid projection coordinates."
+    "These parameters enable subsetting operations based on the Original-grid projection coordinates."
    ]
   },
   {
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To demonstrate the data retrieval process, we provide an example comparing plots of similar regions using the toolbox. We first illustrate how to download datasets in geographical coordinates, followed by the original-grid projection method."
+    "To demonstrate the data retrieval process, we provide an example comparing plots of similar regions using the toolbox. We first illustrate how to download datasets in geographical coordinates, followed by the Original-grid projection method."
    ]
   },
   {
@@ -2010,7 +2010,7 @@
     "copernicusmarine describe -i cmems_mod_arc_phy_my_hflux_P1M-m -r coordinates,label,name,service_name -e values\n",
     "```\n",
     "\n",
-    "*Note: Always verify the correct dataset part (typically the second part for original-grid data) when using describe.*"
+    "*Note: Always verify the correct dataset part (typically the second part for Original-grid data) when using describe.*"
    ]
   },
   {

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -43,7 +43,7 @@ Sparse data subsetting
 -----------------------
 
 On the one hand, some of the datasets available on Copernicus Marine are gridded datasets, benefiting from all the features of the Copernicus Marine Toolbox.
-On the other hand, certain datasets are time series for a given platform; these are called sparse or in-situ datasets. These datasets are processed and formatted differently within the ARCO data framework. See the `INSITU datasets <https://data.marine.copernicus.eu/products?q=insitu>`_ for example.
+On the other hand, certain datasets are time series for a given platform; these are called sparse or in-situ datasets. These datasets are processed and formatted differently within the ARCO data framework. See the `in-situ datasets <https://data.marine.copernicus.eu/products?facets=sources%7EIn-situ+observations>`_ for example.
 
 We can download all the time series of a given geographical area via the ``subset`` command. It will return the data in a tabular format, such as a Pandas DataFrame, a CSV file, or a Parquet database.
 

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -43,9 +43,9 @@ Sparse data subsetting
 -----------------------
 
 On the one hand, some of the datasets available on Copernicus Marine are gridded datasets, benefiting from all the features of the Copernicus Marine Toolbox.
-On the other hand, certain datasets are sparse or INSITU datasets. These datasets are processed and formatted differently within the ARCO data framework. See the `INSITU datasets <https://data.marine.copernicus.eu/products?q=insitu>`_ for example.
+On the other hand, certain datasets are time series for a given platform; these are called sparse or in-situ datasets. These datasets are processed and formatted differently within the ARCO data framework. See the `INSITU datasets <https://data.marine.copernicus.eu/products?q=insitu>`_ for example.
 
-Sparse datasets can be subset using the ``subset`` command, which returns the data in a tabular format, such as a Pandas DataFrame, a CSV file, or a Parquet database.
+We can download all the time series of a given geographical area via the ``subset`` command. It will return the data in a tabular format, such as a Pandas DataFrame, a CSV file, or a Parquet database.
 
 **Example:**
 
@@ -53,7 +53,7 @@ Sparse datasets can be subset using the ``subset`` command, which returns the da
 
   copernicusmarine subset -i cmems_obs-ins_arc_phybgcwav_mynrt_na_irr -y 45 -Y 90 -x -146.99 -X 180 -z 0 -Z 10 --start-datetime "2023-11-25T00:00:00" -T "2024-11-26T03:00:00" --dataset-part history --platform-id B-Sulafjorden___MO --platform-id F-Vartdalsfjorden___MO
 
-Then it can be opened with pandas:
+This dataset can be opened with pandas:
 
 .. code-block:: python
 

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -231,9 +231,8 @@ Option ``--raise-if-updating``
 .. note::
   This option only applies to ARCO services (``arco-geo-series`` and ``arco-time-series``) and not native files (``original-files`` service).
 
-When a dataset is being updated, it can happen that data after a certain date becomes unreliable. When setting this flag,
-the toolbox will raise an error if the subset requested interval overpasses the updating start date. By default, the flag is not set
-and the toolbox will only emit a warning. See ``updating_start_date`` in class :class:`copernicusmarine.CopernicusMarinePart` and custom exception :class:`copernicusmarine.DatasetUpdating`.
+When a dataset is being updated, data after a certain date may become unreliable. If this flag is set, the toolbox will raise an error if the requested subset interval extends beyond the updating start date.
+ By default, the flag is not set and the toolbox will only emit a warning. See ``updating_start_date`` in class :class:`copernicusmarine.CopernicusMarinePart` and custom exception :class:`copernicusmarine.DatasetUpdating`.
 
 .. code-block:: python
 

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -45,7 +45,7 @@ Sparse data subsetting
 On the one hand, some of the datasets available on Copernicus Marine are gridded datasets, benefiting from all the features of the Copernicus Marine Toolbox.
 On the other hand, certain datasets are time series for a given platform; these are called sparse or in-situ datasets. These datasets are processed and formatted differently within the ARCO data framework. See the `in-situ datasets <https://data.marine.copernicus.eu/products?facets=sources%7EIn-situ+observations>`_ for example.
 
-We can download all the time series of a given geographical area via the ``subset`` command. It will return the data in a tabular format, such as a Pandas DataFrame, a CSV file, or a Parquet database.
+We can download all the time series of a given geographical area and time period via the ``subset``. Options can also be used to choose the platforms, variables or depth ranges we are interested in. It will return the data in a tabular format, such as a Pandas DataFrame, a CSV file, or a Parquet database.
 
 **Example:**
 

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -232,7 +232,7 @@ Option ``--raise-if-updating``
   This option only applies to ARCO services (``arco-geo-series`` and ``arco-time-series``) and not native files (``original-files`` service).
 
 When a dataset is being updated, data after a certain date may become unreliable. If this flag is set, the toolbox will raise an error if the requested subset interval extends beyond the updating start date.
- By default, the flag is not set and the toolbox will only emit a warning. See ``updating_start_date`` in class :class:`copernicusmarine.CopernicusMarinePart` and custom exception :class:`copernicusmarine.DatasetUpdating`.
+ By default, the flag is not set and the toolbox will only emit a warning. See ``arco_updating_start_date`` in class :class:`copernicusmarine.CopernicusMarinePart` and custom exception :class:`copernicusmarine.DatasetUpdating`.
 
 .. code-block:: python
 
@@ -259,7 +259,7 @@ For ARCO services in Original-grid part datasets, the following options are avai
   - ``--minimum-y`` or ``-y`` : The minimum y-axis coordinate.
   - ``--maximum-y`` or ``-Y`` : The maximum y-axis coordinate.
 
-For more context and examples, check the  :ref:`original-grid page <stereographic-subsetting-page>`.
+For more context and examples, check the  :ref:`Original-grid page <stereographic-subsetting-page>`.
 
 .. note:
 

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -250,14 +250,15 @@ and the toolbox will only emit a warning. See ``updating_start_date`` in class :
 
 .. _stereographic-subset-usage:
 
-Options for Arco with original-grid
+Options for Arco with Original-grid
 """"""""""""""""""""""""""""""""""""""""""
 
-For ARCO services in original-grid part datasets, the following options are available to subset the area:
-- ``--minimum-x``: The minimum x-axis coordinate.
-- ``--maximum-x``: The maximum x-axis coordinate.
-- ``--minimum-y``: The minimum y-axis coordinate.
-- ``--maximum-y``: The maximum y-axis coordinate.
+For ARCO services in Original-grid part datasets, the following options are available to bound the subsetted area:
+
+  - ``--minimum-x`` or ``-x`` : The minimum x-axis coordinate.
+  - ``--maximum-x``or ``-X`` : The maximum x-axis coordinate.
+  - ``--minimum-y`` or ``-y`` : The minimum y-axis coordinate.
+  - ``--maximum-y`` or ``-Y`` : The maximum y-axis coordinate.
 
 For more context and examples, check the  :ref:`original-grid page <stereographic-subsetting-page>`.
 


### PR DESCRIPTION
Re-read the modified parts of the documentation and updated them accordingly

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--314.org.readthedocs.build/en/314/

<!-- readthedocs-preview copernicusmarine end -->