### PR TITLE
[fix] correcting a typography in the documentation

### DIFF
--- a/doc/usage/stereo_subset.ipynb
+++ b/doc/usage/stereo_subset.ipynb
@@ -2012,49 +2012,6 @@
     "\n",
     "*Note: Always verify the correct dataset part (typically the second part for Original-grid data) when using describe.*"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## List of datasets that have Original-grid projection"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Datasets with \"originalGrid\" part:\n",
-    "- ``cmems_mod_arc_bgc_anfc_ecosmo_P1D-m``\n",
-    "- ``cmems_mod_arc_bgc_anfc_ecosmo_P1M-m``\n",
-    "- ``cmems_mod_arc_phy_anfc_6km_detided_PT1H-i``\n",
-    "- ``cmems_mod_arc_phy_anfc_6km_detided_PT6H-m``\n",
-    "- ``cmems_mod_arc_phy_anfc_6km_detided_P1D-m``\n",
-    "- ``cmems_mod_arc_phy_anfc_6km_detided_P1M-m``\n",
-    "- ``cmems_mod_arc_bgc_my_ecosmo_P1D-m``\n",
-    "- ``cmems_mod_arc_bgc_my_ecosmo_P1M``\n",
-    "- ``cmems_mod_arc_bgc_my_ecosmo_P1Y``\n",
-    "- ``cmems_mod_arc_phy_my_topaz4_P1D-m``\n",
-    "- ``cmems_mod_arc_phy_my_topaz4_P1M``\n",
-    "- ``cmems_mod_arc_phy_my_topaz4_P1Y``\n",
-    "- ``cmems_mod_arc_phy_my_hflux_P1D-m``\n",
-    "- ``cmems_mod_arc_phy_my_hflux_P1M-m``\n",
-    "- ``cmems_mod_arc_phy_my_mflux_P1D-m\"``\n",
-    "- ``cmems_mod_arc_phy_my_mflux_P1M-m``\n",
-    "- ``cmems_mod_arc_phy_my_nextsim_P1M-m``\n",
-    "- ``DMI-ARC-SEAICE_BERG_MOSAIC-L4-NRT-OBS``\n",
-    "- ``DMI-ARC-SEAICE_BERG_MOSAIC_IW-L4-NRT-OBS``\n",
-    "- ``cmems_obs-wind_arc_phy_my_l3-s1a-sar-asc-0.01deg_P1D-i``\n",
-    "- ``cmems_obs-wind_arc_phy_my_l3-s1a-sar-desc-0.01deg_P1D-i``\n",
-    "- ``cmems_obs-si_arc_physic_nrt_1km-grl_P1D-irr``\n",
-    "- ``DMI-ARC-SEAICE_BERG_IW-L4-NRT-OBS``\n",
-    "- ``DMI-ARC-SEAICE_BERG-L4-NRT-OBS``\n",
-    "- ``cmems_obs-si_arc_physic_nrt_1km-grl_P1WT3D-m``\n",
-    "- ``cmems_obs-si_arc_phy_nrt_1km-svb_P1D-irr``\n",
-    "- ``cmems_mod_arc_phy_my_nextsim_P1D-m``\n",
-    "- ``cmems_mod_arc_phy_anfc_nextsim_hm``\n",
-    "- ``cmems_mod_arc_phy_anfc_nextsim_P1M-m``"
-   ]
   }
  ],
  "metadata": {

--- a/doc/usage/stereo_subset.ipynb
+++ b/doc/usage/stereo_subset.ipynb
@@ -1866,7 +1866,7 @@
     "import cartopy.feature as cfeature\n",
     "\n",
     "# Select chlorophyll data for the specific date\n",
-    "chl = dataset_lonlat.sel(time=\"2021-01-01\").chl.squeeze() # Single time-point selection\n",
+    "chl = dataset_stereographic.sel(time=\"2021-01-01\").chl.squeeze() # Single time-point selection\n",
     "\n",
     "fig = plt.figure(figsize=(10,6), dpi=100)\n",
     "fig.patch.set_visible(True)\n",
@@ -2073,7 +2073,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The stereographic subset page seems to have this little typography error.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--318.org.readthedocs.build/en/318/

<!-- readthedocs-preview copernicusmarine end -->