### PR TITLE
fix: default to -1 for chunk_size_limit

### DIFF
--- a/copernicusmarine/python_interface/open_dataset.py
+++ b/copernicusmarine/python_interface/open_dataset.py
@@ -119,7 +119,7 @@ def open_dataset(
         Force download through one of the available services using the service name among ['arco-geo-series', 'arco-time-series', 'omi-arco', 'static-arco', 'arco-platform-series'] or its short name among ['geoseries', 'timeseries', 'omi-arco', 'static-arco', 'platformseries'].
     credentials_file : Union[pathlib.Path, str], optional
         Path to a credentials file if not in its default directory (``$HOME/.copernicusmarine``). Accepts .copernicusmarine-credentials / .netrc or _netrc / motuclient-python.ini files.
-    chunk_size_limit : int, default 100
+    chunk_size_limit : int, default -1
         Limit the size of the chunks in the dask array. Default is set to -1 which behaves similarly to 'chunks=auto' from ``xarray``. Positive integer values and '-1' are accepted. This is an experimental feature.
 
     Returns

--- a/copernicusmarine/python_interface/subset.py
+++ b/copernicusmarine/python_interface/subset.py
@@ -142,7 +142,7 @@ def subset(
         Specify a compression level to apply on the NetCDF output file. A value of 0 means no compression, and 9 is the highest level of compression available.
     netcdf3_compatible : bool, optional
         Enable downloading the dataset in a netCDF3 compatible format.
-    chunk_size_limit : int, default 100
+    chunk_size_limit : int, default -1
         Limit the size of the chunks in the dask array. Default is set to -1 which behaves similarly to 'chunks=auto' from ``xarray``. Positive integer values and '-1' are accepted. This is an experimental feature.
     raise_if_updating : bool, default False
         If set, raises a :class:`copernicusmarine.DatasetUpdating` error if the dataset is being updated and the subset interval requested overpasses the updating start date of the dataset. Otherwise, a simple warning is displayed.


### PR DESCRIPTION
Update the documentation, as in some parts the default was still set to 100 for the `chunk_size_limit` feature.

I think those are the places pointed out in https://github.com/mercator-ocean/copernicus-marine-toolbox/issues/267 . Thanks again :)

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--325.org.readthedocs.build/en/325/

<!-- readthedocs-preview copernicusmarine end -->