### PR TITLE
fix: pass units in the encoding

### DIFF
--- a/copernicusmarine/download_functions/download_zarr.py
+++ b/copernicusmarine/download_functions/download_zarr.py
@@ -616,7 +616,13 @@ def _download_dataset_as_netcdf(
             contiguous=False,
             shuffle=True,
         )
-        keys_to_keep = {"scale_factor", "add_offset", "dtype", "_FillValue"}
+        keys_to_keep = {
+            "scale_factor",
+            "add_offset",
+            "dtype",
+            "_FillValue",
+            "units",
+        }
         encoding = {
             name: {
                 **{

--- a/tests/test_python_interface.py
+++ b/tests/test_python_interface.py
@@ -17,6 +17,7 @@ from copernicusmarine import (
 from copernicusmarine.download_functions.utils import (
     timestamp_or_datestring_to_datetime,
 )
+from tests.test_utils import execute_in_terminal
 
 
 class TestPythonInterface:
@@ -325,6 +326,22 @@ class TestPythonInterface:
         diff.to_netcdf(tmp_path / "diff.nc")
         diff = xarray.open_dataset(tmp_path / "diff.nc")
         assert diff.thetao.mean().values == 0.0
+        output_uncompressed = execute_in_terminal(
+            [
+                "ncdump",
+                "-h",
+                str(tmp_path / "uncompressed_data.nc"),
+            ]
+        )
+        output_compressed = execute_in_terminal(
+            [
+                "ncdump",
+                "-h",
+                str(tmp_path / "compressed_data.nc"),
+            ]
+        )
+        # we skip the first line that contains the title
+        assert output_compressed.stdout[23:] == output_uncompressed.stdout[25:]
 
     def test_lonlat_attributes_when_not_in_arco(self, tmp_path):
         dataset_response = subset(


### PR DESCRIPTION
Pass along the units also in the enconding dict, so that they are kept for the variables.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--333.org.readthedocs.build/en/333/

<!-- readthedocs-preview copernicusmarine end -->