### PR TITLE
deprecated to custom deprecated

### DIFF
--- a/copernicusmarine/command_line_interface/group_subset.py
+++ b/copernicusmarine/command_line_interface/group_subset.py
@@ -19,7 +19,7 @@ from copernicusmarine.command_line_interface.utils import (
 from copernicusmarine.core_functions import documentation_utils
 from copernicusmarine.core_functions.click_custom_class import (
     CustomClickOptionsCommand,
-    DeprecatedClickOption,
+    CustomDeprecatedClickOption,
 )
 from copernicusmarine.core_functions.fields_query_builder import (
     build_query,
@@ -284,7 +284,7 @@ def cli_subset() -> None:
     "--motu-api-request",
     type=str,
     help=documentation_utils.SUBSET["MOTU_API_REQUEST_HELP"],
-    cls=DeprecatedClickOption,
+    cls=CustomDeprecatedClickOption,
     deprecated=["--motu-api-request"],
 )
 @click.option(

--- a/copernicusmarine/command_line_interface/utils.py
+++ b/copernicusmarine/command_line_interface/utils.py
@@ -6,7 +6,7 @@ from click.core import ParameterSource
 
 from copernicusmarine.core_functions import documentation_utils
 from copernicusmarine.core_functions.click_custom_class import (
-    DeprecatedClickOption,
+    CustomDeprecatedClickOption,
 )
 
 
@@ -97,6 +97,6 @@ force_download_option = click.option(
     is_flag=True,
     default=False,
     hidden=True,
-    cls=DeprecatedClickOption,
+    cls=CustomDeprecatedClickOption,
     deprecated=["--force-download"],
 )

--- a/copernicusmarine/core_functions/click_custom_class.py
+++ b/copernicusmarine/core_functions/click_custom_class.py
@@ -10,9 +10,9 @@ from copernicusmarine.core_functions.deprecated_options import (
 logger = logging.getLogger("copernicusmarine")
 
 
-class DeprecatedClickOption(click.Option):
+class CustomDeprecatedClickOption(click.Option):
     def __init__(self, *args, **kwargs):
-        self.deprecated = kwargs.pop("deprecated", ())
+        self.deprecated = kwargs.pop("custom_deprecated", ())
         self.preferred = kwargs.pop("preferred", None)
         super().__init__(*args, **kwargs)
 
@@ -26,15 +26,17 @@ class CustomClickOptionsCommand(click.Command):
         options |= set(parser._long_opt.values())
 
         for option in options:
-            if not isinstance(option.obj, DeprecatedClickOption):
+            if not isinstance(option.obj, CustomDeprecatedClickOption):
                 continue
 
             def make_process(an_option):
                 orig_process = an_option.process
-                deprecated = getattr(an_option.obj, "deprecated", None)
+                custom_deprecated = getattr(an_option.obj, "deprecated", None)
                 preferred = getattr(an_option.obj, "preferred", None)
                 msg = "Expected `deprecated` value for `{}`"
-                assert deprecated is not None, msg.format(an_option.obj.name)
+                assert custom_deprecated is not None, msg.format(
+                    an_option.obj.name
+                )
 
                 def process(value, state):
                     frame = inspect.currentframe()
@@ -44,7 +46,7 @@ class CustomClickOptionsCommand(click.Command):
                     finally:
                         del frame
 
-                    if opt in deprecated:
+                    if opt in custom_deprecated:
                         log_deprecated_message(opt, preferred)
                     return orig_process(value, state)
 

--- a/tests/__snapshots__/test_help_command_interface.ambr
+++ b/tests/__snapshots__/test_help_command_interface.ambr
@@ -399,7 +399,7 @@
     '  --motu-api-request TEXT         Option to pass a complete MOTU API request',
     '                                  as a string. Caution, user has to replace',
     '                                  double quotes " with single quotes \\\' in the',
-    '                                  request.',
+    '                                  request.(DEPRECATED)',
     '  --dry-run                       If True, runs query without downloading',
     '                                  data.',
     '  -r, --response-fields TEXT      List of fields to include in the query',


### PR DESCRIPTION
We found out that the latest release from click crashes with our deprecated options, see [CMT-245](https://cms-change.atlassian.net/browse/CMT-245).

As discovered by Renaud, in the argument initialisation there is a boolean that is `deprecated` so better keep the naming different. This looks to solve the current problem.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--340.org.readthedocs.build/en/340/

<!-- readthedocs-preview copernicusmarine end -->

[CMT-245]: https://cms-change.atlassian.net/browse/CMT-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ