### PR TITLE
fix: unify pre-release name

### DIFF
--- a/.github/workflows/binary-test-windows.yml
+++ b/.github/workflows/binary-test-windows.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - "main"
       - "release/**"
-      - "pre-releases/**"
+      - "pre-release/**"
   pull_request_target:
     branches:
       - "main"

--- a/.github/workflows/binary-test.yml
+++ b/.github/workflows/binary-test.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - "main"
       - "release/**"
-      - "pre-releases/**"
+      - "pre-release/**"
   pull_request_target:
     branches:
       - "main"

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "main"
       - "release/**"
-      - "pre-releases/**"
+      - "pre-release/**"
   pull_request:
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "main"
       - "release/**"
-      - "pre-releases/**"
+      - "pre-release/**"
   push:
     branches:
       - "main"

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -161,7 +161,7 @@ The Copernicus Marine Toolbox has the following dependencies:
 - `numpy <https://www.numpy.org/>`__ (1.23 or later)
 - `pydantic <https://docs.pydantic.dev/>`__ (2.9.1 or later)
 - `h5netcdf <https://h5netcdf.org>`__ (1.4.0 or later)
-- `arcosparse <https://pypi.org/project/arcosparse/>`__ (0.4.0 or later)
+- `arcosparse <https://pypi.org/project/arcosparse/>`__ (0.4.2 or later)
 
 
 The Copernicus Marine Toolbox uses the xarray library to handle the data when using the ``subset`` command in the majority of cases.


### PR DESCRIPTION
"pre-releases" to "pre-release" for consistency 

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--361.org.readthedocs.build/en/361/

<!-- readthedocs-preview copernicusmarine end -->