### PR TITLE
[fix] exclude tests folder to coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - "tests/**/*"
+  - "tests"


### PR DESCRIPTION
We want to see the coverage on the actual code, not on the tests that we run! Hopefully this will solve it.

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--363.org.readthedocs.build/en/363/

<!-- readthedocs-preview copernicusmarine end -->