### PR TITLE
fix: read only open zarr

### DIFF
--- a/copernicusmarine/core_functions/custom_open_zarr.py
+++ b/copernicusmarine/core_functions/custom_open_zarr.py
@@ -43,5 +43,6 @@ def open_zarr(
             bucket=bucket,
             root_path=root_path,
             copernicus_marine_username=copernicus_marine_username,
+            read_only=True,
         )
         return xarray.open_zarr(store, **kwargs, zarr_format=2)

--- a/copernicusmarine/core_functions/custom_s3_store_zarr_v3.py
+++ b/copernicusmarine/core_functions/custom_s3_store_zarr_v3.py
@@ -25,8 +25,9 @@ class CustomS3StoreZarrV3(Store):
         copernicus_marine_username: Optional[str] = None,
         number_of_retries: int = 9,
         initial_retry_wait_seconds: int = 1,
+        **kwargs,
     ):
-        super().__init__()
+        super().__init__(**kwargs)
         self._root_path = root_path.lstrip("/")
         self._bucket = bucket
         self.client, _ = get_configured_boto3_session(


### PR DESCRIPTION
fix [issue reported here ](https://github.com/zarr-developers/zarr-python/issues/3189)

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--370.org.readthedocs.build/en/370/

<!-- readthedocs-preview copernicusmarine end -->