### PR TITLE
fix: typo in the branches triggered for tests on oss

### DIFF
--- a/.github/workflows/tests_on_oss.yml
+++ b/.github/workflows/tests_on_oss.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "main"
       - "release/**"
-      - "pre-releases/**"
+      - "pre-release/**"
 
 jobs:
   tests:


### PR DESCRIPTION
Should be triggered on `pre-release` not `pre-releases`

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--376.org.readthedocs.build/en/376/

<!-- readthedocs-preview copernicusmarine end -->