### PR TITLE
fix: small downloads no dask even with many variables

### DIFF
--- a/copernicusmarine/download_functions/download_zarr.py
+++ b/copernicusmarine/download_functions/download_zarr.py
@@ -419,7 +419,7 @@ def get_optimum_dask_chunking(
     )
     if chunk_size_limit == -1:
         # TODO: investigate in depth what are the optimal values.
-        # For now, we use the default values that seems to work well
+        # For now, we use the default values that seem to work well
         # for our examples but we should investigate more.
         if zarr_chunks_to_download <= 50:
             return None


### PR DESCRIPTION
In this example: we shouldn't use dask chunks as it seems to be the most optimal.


```
copernicusmarine subset -i cmems_mod_bal_wav_my_PT1H-i -t "2025-03-31 23:00:00" -T "2025-04-01 00:00:00" -Z 1 -o todelete -x 18 -X 20.5 -y 61 -Y 62.5 --log-level DEBUG
```

But since there was a lot a variables it was using dask

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--377.org.readthedocs.build/en/377/

<!-- readthedocs-preview copernicusmarine end -->