### PR TITLE
[doc-update] remove old auth system mention

### DIFF
--- a/copernicusmarine/core_functions/credentials_utils.py
+++ b/copernicusmarine/core_functions/credentials_utils.py
@@ -102,7 +102,7 @@ class CouldNotConnectToAuthenticationSystem(Exception):
     Please check the following common problems:
 
     - Check your internet connection
-    - Make sure to authorize ``cmems-cas.cls.fr`` and/or ``auth.marine.copernicus.eu`` domains
+    - Make sure to authorize ``auth.marine.copernicus.eu`` domain
 
     If none of this worked, maybe the authentication system is down, please try again later.
     """  # noqa

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -206,7 +206,7 @@ Domains required by the Copernicus Marine Toolbox
 ********************************************************
 To be able to use the Copernicus Marine Services, you need to be able to access those domains:
 
-- ``https://auth.marine.copernicus.eu``: for the new authentication process.
+- ``https://auth.marine.copernicus.eu``: for the authentication process.
 - ``https://s3.waw3-1.cloudferro.com``: for the data and the metadata.
 - ``https://s3.waw4-1.cloudferro.com``: for the data and the metadata.
 - ``https://stac.marine.copernicus.eu``: for the metadata.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -206,7 +206,6 @@ Domains required by the Copernicus Marine Toolbox
 ********************************************************
 To be able to use the Copernicus Marine Services, you need to be able to access those domains:
 
-- ``https://cmems-cas.cls.fr``: for the old authentication process.
 - ``https://auth.marine.copernicus.eu``: for the new authentication process.
 - ``https://s3.waw3-1.cloudferro.com``: for the data and the metadata.
 - ``https://s3.waw4-1.cloudferro.com``: for the data and the metadata.

--- a/doc/usage/login-usage.rst
+++ b/doc/usage/login-usage.rst
@@ -17,16 +17,10 @@ The ``login`` command creates a configuration file called ``.copernicusmarine-cr
 
 If the ``.copernicusmarine-credentials`` file already exists, the system will ask for confirmation before overwriting it. You can also use option ``–-force-overwrite`` to skip confirmation.
 
-New Copernius Marine authentication system
+Old Copernius Marine authentication system
 -------------------------------------------
 
-A new Copernius Marine authentication system will be released in the following months after the release of the Copernicus Marine Toolbox version 2.0.0.
-From 2.0.0, the toolbox should be able to handle both the old and the new authentication systems.
-
-If you are blocking some domains, you will need to authorize the domain ``auth.marine.copernicus.eu`` to be able to connect when the old system is decomissioned.
-
-.. note::
-    One of limitation of the old system is that it goes through HTTP (through redirections) and not HTTPS. The new system will use HTTPS only.
+From 9th July 2025, the old Copernicus Marine authentication system is deprecated.
 
 Access points migration and evolution
 -------------------------------------

--- a/doc/usage/login-usage.rst
+++ b/doc/usage/login-usage.rst
@@ -17,11 +17,6 @@ The ``login`` command creates a configuration file called ``.copernicusmarine-cr
 
 If the ``.copernicusmarine-credentials`` file already exists, the system will ask for confirmation before overwriting it. You can also use option ``–-force-overwrite`` to skip confirmation.
 
-Old Copernius Marine authentication system
--------------------------------------------
-
-From 9th July 2025, the old Copernicus Marine authentication system is deprecated.
-
 Access points migration and evolution
 -------------------------------------
 


### PR DESCRIPTION
Remove the mentioning of the old authentication system from the error.

Do you think that we should say something, between now and when we remove the old-car completely from the code, about checking that the credentials are okey? Or would it be a problem onwards, once solved?

Let me know what you think!

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--380.org.readthedocs.build/en/380/

<!-- readthedocs-preview copernicusmarine end -->