### PR TITLE
[doc-update] update old documentation CMT-284

### DIFF
--- a/doc/changelog/v221.rst
+++ b/doc/changelog/v221.rst
@@ -3,6 +3,14 @@ Release 2.2.1
 
 Patch release with bug fixes and improvements.
 
+General
+------
+
+Fixes
+^^^^^
+
+* Updated the documentation output for some commands.
+
 Login
 ------
 

--- a/doc/changelog/v221.rst
+++ b/doc/changelog/v221.rst
@@ -9,7 +9,7 @@ General
 Fixes
 ^^^^^
 
-* Updated the documentation output for some commands.
+* Updated the output of some commands in the documentation.
 
 Login
 ------

--- a/doc/usage/get-usage.rst
+++ b/doc/usage/get-usage.rst
@@ -10,23 +10,23 @@ Download the dataset file(s) as originally produced, based on the dataset ID or 
 
 .. code-block:: bash
 
-    copernicusmarine get --dataset-id cmems_mod_ibi_phy_my_0.083deg-3D_P1Y-m --log-level DEBUG
+    copernicusmarine get --dataset-id cmems_mod_ibi_phy_my_0.083deg-3D_P1Y-m
 
 **Returns:**
 
 .. code-block:: bash
 
-    INFO - 2024-04-03T11:39:18Z - Dataset version was not specified, the latest one was selected: "202211"
-    INFO - 2024-04-03T11:39:18Z - Dataset part was not specified, the first one was selected: "default"
-    INFO - 2024-04-03T11:39:18Z - Service was not specified, the default one was selected: "original-files"
-    INFO - 2024-04-03T11:39:18Z - Downloading using service original-files...
-    DEBUG - 2024-04-03T11:39:19Z - You requested the download of the following files:
-    s3://mdl-native-10/native/IBI_MULTIYEAR_PHY_005_002/cmems_mod_ibi_phy_my_0.083deg-3D_P1Y-m_202211/CMEMS_v5r1_IBI_PHY_MY_NL_01yav_19930101_19931231_R20221101_RE01.nc - 8.83 MB - 2023-11-12T23:47:13Z
-    [...]
-    s3://mdl-native-10/native/IBI_MULTIYEAR_PHY_005_002/cmems_mod_ibi_phy_my_0.083deg-3D_P1Y-m_202211/CMEMS_v5r1_IBI_PHY_MY_NL_01yav_20120101_20121231_R20221101_RE01.nc - 8.62 MB - 2023-11-12T23:47:14Z
-    Printed 20 out of 29 files
-
-    Total size of the download: 252.94 MB
+    INFO - 2025-07-10T13:11:13Z - Selected dataset version: "202211"
+    INFO - 2025-07-10T13:11:13Z - Selected dataset part: "default"
+    INFO - 2025-07-10T13:11:13Z - Listing files on remote server...
+    1it [00:00,  2.74it/s]
+    Downloading files: 100%|████████████████████████████████████████████████████████████████████████████████████████████| 31/31 [00:25<00:00,  1.22it/s]
+    {
+      "number_of_files_to_download": 31,
+      "total_size": 258.66549015045166,
+      "status": "000",
+      "message": "The request was successful."
+    }
 
 **By default:**
 

--- a/doc/usage/shared-options.rst
+++ b/doc/usage/shared-options.rst
@@ -256,6 +256,8 @@ When used, the toolbox will by default, send the full return response of the com
 See :ref:`Response types documentation <response-types>` for more information about the response you can expect.
 
 
+.. _log-level:
+
 Option ``--log-level``
 *********************************
 

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -20,7 +20,7 @@ The ``subset`` command allows you to remotely subset a dataset based on variable
   INFO - 2025-07-10T13:18:03Z - Selected dataset part: "default"
   INFO - 2025-07-10T13:18:05Z - Starting download. Please wait...
   100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 44/44 [00:10<00:00,  4.03it/s]
-  INFO - 2025-07-10T13:18:16Z - Successfully downloaded to cmems_mod_ibi_phy_my_0.083deg-3D_P1D-m_thetao-so_0.08E_28.00N-28.08N_0.51-5698.06m_2021-01-01-2021-01-03_(1).nc
+  INFO - 2025-07-10T13:18:16Z - Successfully downloaded to cmems_mod_ibi_phy_my_0.083deg-3D_P1D-m_thetao-so_0.08E_28.00N-28.08N_0.51-5698.06m_2021-01-01-2021-01-03.nc
   {
     "file_size": 0.01414503816793893,
     "data_transfer_size": 422.5758778625954,

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -28,7 +28,7 @@ The ``subset`` command allows you to remotely subset a dataset based on variable
     "message": "The request was successful."
   }
 
-Using log level DEBUG, a summary of the dataset subset is displayed.
+Using log level DEBUG, a summary of the dataset subset is displayed. Check the :ref:`documentation about log-level option <log-level>` for more information.
 
 .. _sparse-subset:
 

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -10,30 +10,23 @@ The ``subset`` command allows you to remotely subset a dataset based on variable
 
 .. code-block:: bash
 
-    copernicusmarine subset --dataset-id cmems_mod_ibi_phy_my_0.083deg-3D_P1D-m --variable thetao --variable so --start-datetime 2021-01-01 --end-datetime 2021-01-03 --minimum-longitude 0.0 --maximum-longitude 0.1 --minimum-latitude 28.0 --maximum-latitude 28.1 --log-level DEBUG
+    copernicusmarine subset --dataset-id cmems_mod_ibi_phy_my_0.083deg-3D_P1D-m --variable thetao --variable so --start-datetime 2021-01-01 --end-datetime 2021-01-03 --minimum-longitude 0.0 --maximum-longitude 0.1 --minimum-latitude 28.0 --maximum-latitude 28.1
 
 **Returns:**
 
 .. code-block:: bash
 
-    DEBUG - 2024-04-03T10:18:18Z - <xarray.Dataset> Size: 3kB
-    Dimensions:    (depth: 50, latitude: 2, longitude: 1, time: 3)
-    Coordinates:
-      * depth      (depth) float32 200B 0.5058 1.556 2.668 ... 5.292e+03 5.698e+03
-      * latitude   (latitude) float32 8B 28.0 28.08
-      * longitude  (longitude) float32 4B 0.08333
-      * time       (time) datetime64[ns] 24B 2021-01-01 2021-01-02 2021-01-03
-    Data variables:
-        thetao     (time, depth, latitude, longitude) float32 1kB dask.array<chunksize=(3, 1, 2, 1), meta=np.ndarray>
-        so         (time, depth, latitude, longitude) float32 1kB dask.array<chunksize=(3, 1, 2, 1), meta=np.ndarray>
-    Attributes: (12/20)
-        Conventions:               CF-1.0
-        bulletin_date:             2020-12-01
-        references:                http://marine.copernicus.eu
-        copernicusmarine_version:  1.1.0
-    INFO - 2024-04-03T10:18:18Z - Estimated size of the dataset file is 0.002 MB.
-    Estimated size of the data that needs to be downloaded to obtain the result: 207 MB
-    This a very rough estimation and usually its higher than the actual size of the data that needs to be downloaded.
+  INFO - 2025-07-10T13:18:03Z - Selected dataset version: "202012"
+  INFO - 2025-07-10T13:18:03Z - Selected dataset part: "default"
+  INFO - 2025-07-10T13:18:05Z - Starting download. Please wait...
+  100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 44/44 [00:10<00:00,  4.03it/s]
+  INFO - 2025-07-10T13:18:16Z - Successfully downloaded to cmems_mod_ibi_phy_my_0.083deg-3D_P1D-m_thetao-so_0.08E_28.00N-28.08N_0.51-5698.06m_2021-01-01-2021-01-03_(1).nc
+  {
+    "file_size": 0.01414503816793893,
+    "data_transfer_size": 422.5758778625954,
+    "status": "000",
+    "message": "The request was successful."
+  }
 
 Using log level DEBUG, a summary of the dataset subset is displayed. It is by default displayed when using the ``--dry-run`` option.
 

--- a/doc/usage/subset-usage.rst
+++ b/doc/usage/subset-usage.rst
@@ -28,7 +28,7 @@ The ``subset`` command allows you to remotely subset a dataset based on variable
     "message": "The request was successful."
   }
 
-Using log level DEBUG, a summary of the dataset subset is displayed. It is by default displayed when using the ``--dry-run`` option.
+Using log level DEBUG, a summary of the dataset subset is displayed.
 
 .. _sparse-subset:
 


### PR DESCRIPTION
In relation to [CMT-284](https://cms-change.atlassian.net/browse/CMT-284) we want to make sure that the responses that are showed in the documentation are accordingly to the current version.

Maybe we should think of some way to keep the documentation up to date without having to think about it too much, no? 

Also, I removed the `--log-level DEBUG` because I feel like it is too verbose.

[CMT-284]: https://cms-change.atlassian.net/browse/CMT-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--383.org.readthedocs.build/en/383/

<!-- readthedocs-preview copernicusmarine end -->