### PR TITLE
[fix] Dependencies test on windows

### DIFF
--- a/.github/workflows/dependencies-tests.yml
+++ b/.github/workflows/dependencies-tests.yml
@@ -1,6 +1,9 @@
 name: Dependencies tests
 
 on:
+  push:
+    branches:
+      - "dependency-on-windows"
   schedule:
     - cron: '0 0 * * 6'
 

--- a/tests_dependencies_versions/test_basic_commands.py
+++ b/tests_dependencies_versions/test_basic_commands.py
@@ -79,6 +79,6 @@ class TestBasicCommands:
             f"{os.getenv('COPERNICUSMARINE_SERVICE_PASSWORD')}",
         ]
 
-        self.output = execute_in_terminal(command)
+        self.output = execute_in_terminal(command, safe_quoting=True)
         assert self.output.returncode == 0
         assert non_existing_directory.is_dir()


### PR DESCRIPTION
Fixing the dependencies tests on windows, it crashed 3 weeks ago without a clear reason.