### PR TITLE
[fix] improving toolbox resilience with zarr v2

### DIFF
--- a/copernicusmarine/core_functions/sessions.py
+++ b/copernicusmarine/core_functions/sessions.py
@@ -60,7 +60,7 @@ def get_configured_boto3_session(
 ) -> tuple[Any, Any]:
     config_boto3 = botocore.config.Config(
         signature_version=botocore.UNSIGNED,
-        retries={"max_attempts": 10, "mode": "standard"},
+        retries={"max_attempts": 10, "mode": "adaptive"},
     )
     s3_session = boto3.Session()
     s3_client = s3_session.client(


### PR DESCRIPTION
Looks like the zarr v2 and zarr v3 access the cloud in different ways, meaning that the errors that we are currently getting (https://github.com/mercator-ocean/copernicus-marine-toolbox/issues/400) are not properly considered in zarr v2.

This branch would fix the current state, allowing for v2 to handle the errors too.