### PR TITLE
fix: requests outside dataset interval should raise

### DIFF
--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -771,7 +771,7 @@ def _check_coordinate_overlap(
             dataset_minimum_coordinate_value,
             dataset_maximum_coordinate_value,
         )
-    longitude_overlap, longitude_request_contained = True, True
+    longitude_overlap, longitude_request_contained = False, False
     if dimension == "longitude":
         if dataset_minimum_coordinate_value == -180:
             dataset_maximum_coordinate_value = 180

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -3,6 +3,8 @@ import re
 from json import loads
 from unittest import mock
 
+import pytest
+
 from copernicusmarine import (
     CopernicusMarineCatalogue,
     CopernicusMarineServiceNames,
@@ -93,14 +95,12 @@ class TestDescribe:
         self, mocked_requests, caplog
     ):
         with caplog.at_level(logging.DEBUG, logger="copernicusmarine"):
-            try:
+            with pytest.raises(Exception):
                 describe(
                     raise_on_error=True,
                     product_id="NWSHELF_MULTIYEAR_BGC_004_011",
                 )
-                assert False, "Expected an exception to be raised"
-            except Exception:
-                assert "Stopping describe" in caplog.text
+            assert "Stopping describe" in caplog.text
 
     @mock.patch(
         "requests.Session.get",
@@ -110,17 +110,14 @@ class TestDescribe:
         self, mocked_requests, caplog
     ):
         with caplog.at_level(logging.DEBUG, logger="copernicusmarine"):
-            try:
+            with pytest.raises(Exception):
                 describe(
                     raise_on_error=True,
                     product_id="GLOBAL_ANALYSISFORECAST_PHY_001_024",
                 )
-                assert False, "Expected an exception to be raised"
-            except Exception:
-                assert (
-                    "Failed to fetch or parse JSON for dataset URL:"
-                    in caplog.text
-                )
+            assert (
+                "Failed to fetch or parse JSON for dataset URL:" in caplog.text
+            )
 
     @mock.patch(
         "requests.Session.get",
@@ -130,18 +127,15 @@ class TestDescribe:
         self, mocked_requests, caplog
     ):
         with caplog.at_level(logging.DEBUG, logger="copernicusmarine"):
-            try:
+            with pytest.raises(Exception):
                 describe(
                     raise_on_error=True,
                     product_id="UNAVAILABLE_PRODUCT",
                 )
-                assert False, "Expected an exception to be raised"
-            except Exception:
-                assert (
-                    "Failed to fetch or parse JSON for product URL:"
-                    in caplog.text
-                )
-                assert "UNAVAILABLE_PRODUCT" in caplog.text
+            assert (
+                "Failed to fetch or parse JSON for product URL:" in caplog.text
+            )
+            assert "UNAVAILABLE_PRODUCT" in caplog.text
 
     @mock.patch(
         "requests.Session.get",
@@ -151,14 +145,12 @@ class TestDescribe:
         self, mocked_requests, caplog
     ):
         with caplog.at_level(logging.DEBUG, logger="copernicusmarine"):
-            try:
+            with pytest.raises(Exception):
                 describe(
                     raise_on_error=True,
                     product_id="PRODUCT_W_ERRORS",
                 )
-                assert False, "Expected an exception to be raised"
-            except Exception:
-                assert "Error while parsing product" in caplog.text
+            assert "Error while parsing product" in caplog.text
 
     @mock.patch(
         "requests.Session.get",

--- a/tests/test_get_create_file_list.py
+++ b/tests/test_get_create_file_list.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from copernicusmarine import get
 from tests.test_utils import execute_in_terminal
 
@@ -52,16 +54,15 @@ class TestGetCreateFileList:
             )
 
     def test_get_create_file_list_without_extension_raises_python(self):
-        try:
+        with pytest.raises(AssertionError) as e:
             get(
                 dataset_id="cmems_mod_ibi_phy_my_0.083deg-3D_P1M-m",
                 create_file_list="hello",
+                dry_run=True,
             )
-        except AssertionError as e:
-            assert (
-                str(e)
-                == "Download file list must be a '.txt' or '.csv' file. "
-            )
+        assert "Download file list must be a '.txt' or '.csv' file. " in str(
+            e.value
+        )
 
     def test_get_create_file_list_python(self):
         get(

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import pytest
 import responses
 
 from copernicusmarine import login
@@ -457,8 +458,5 @@ class TestLogin:
             status=503,
         )
 
-        try:
+        with pytest.raises(CouldNotConnectToAuthenticationSystem):
             login(username="toto", password="lololo")
-            assert False, "should raise before"
-        except CouldNotConnectToAuthenticationSystem:
-            pass

--- a/tests/test_originalGrid_datasets.py
+++ b/tests/test_originalGrid_datasets.py
@@ -2,6 +2,7 @@ import pathlib
 import random
 from json import loads
 
+import pytest
 import xarray
 
 from copernicusmarine import open_dataset, read_dataframe, subset
@@ -197,7 +198,7 @@ class TestOriginalGridDatasets:
         )
 
     def test_originalGrid_error_with_open_dataset(self):
-        try:
+        with pytest.raises(Exception) as e:
             _ = open_dataset(
                 dataset_id="cmems_mod_arc_phy_my_topaz4_P1Y",
                 dataset_part="originalGrid",
@@ -210,13 +211,12 @@ class TestOriginalGridDatasets:
                 coordinates_selection_method="outside",
             )
             assert 1 == 0
-        except Exception as e:
-            assert str(e) == (
-                "You cannot specify longitude and latitude when using the "
-                "'originalGrid' dataset part. Try using "
-                "``--minimum-x``, ``--maximum-x``, ``--minimum-y`` "
-                "and ``--maximum-y``."
-            )
+        assert (
+            "You cannot specify longitude and latitude when using the "
+            "'originalGrid' dataset part. Try using "
+            "``--minimum-x``, ``--maximum-x``, ``--minimum-y`` "
+            "and ``--maximum-y``."
+        ) in str(e.value)
 
     def test_originalGrid_alias_work(self):
         command = [

--- a/tests/test_several_metadata_catalogues.py
+++ b/tests/test_several_metadata_catalogues.py
@@ -1,5 +1,6 @@
 import logging
 
+import pytest
 import responses
 from requests.exceptions import HTTPError
 
@@ -69,19 +70,15 @@ class TestSeveralMetadataCatalogues:
             status=400,
         )
 
-        try:
+        with pytest.raises(HTTPError) as e:
             get(dataset_id=dataset_id, dry_run=True, staging=True)
-        except HTTPError as e:
-            assert "400" in str(e)
+        assert "400" in str(e)
 
     def test_raises_when_wrong_dataset_id(self):
         dataset_id = "cmems_mod_glo_phy-thetao_anfc_0.083deg_P1D-m_wrong"
 
-        try:
+        with pytest.raises(DatasetNotFound):
             get(dataset_id=dataset_id, dry_run=True, staging=True)
-            assert False, "Should raise DatasetNotFound"
-        except DatasetNotFound:
-            pass
 
     def test_describe_works(self):
         full_describe = describe(staging=True)
@@ -128,17 +125,11 @@ class TestSeveralMetadataCatalogues:
         )
 
     def test_describe_fails_wrong_ids(self):
-        try:
+        with pytest.raises(ProductNotFound):
             describe(product_id="WRONG_PRODUCT_ID")
-            assert False, "Should raise ProductNotFound"
-        except ProductNotFound:
-            pass
 
-        try:
+        with pytest.raises(DatasetNotFound):
             describe(dataset_id="WRONG_DATASET_ID")
-            assert False, "Should raise DatasetNotFound"
-        except DatasetNotFound:
-            pass
 
     @responses.activate
     def test_describe_fails_for_any_error(self):
@@ -149,11 +140,9 @@ class TestSeveralMetadataCatalogues:
             json=None,
             status=400,
         )
-        try:
+        with pytest.raises(HTTPError) as e:
             describe(staging=True)
-            assert False, "Should raise HTTPError"
-        except HTTPError:
-            pass
+        assert "400" in str(e.value)
 
     @responses.activate
     def test_cdn_works_on_prod(self, caplog):

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -228,31 +228,28 @@ class TestSubset:
                 )
 
     def test_file_format_option(self):
-        response = subset(
+        self.response = subset(
             dataset_id="cmems_obs-sst_glo_phy_l3s_pir_P1D-m",
             start_datetime="2023-11-01T00:00:00",
             dry_run=True,
         )
-        assert response.filename.endswith(".nc")
+        assert self.response.filename.endswith(".nc")
 
-        response = subset(
+        self.response = subset(
             dataset_id="cmems_obs-ins_arc_phybgcwav_mynrt_na_irr",
             start_datetime="2023-11-25T00:00:00",
             file_format=None,
             dry_run=True,
         )
-        assert response.filename.endswith(".csv")
+        assert self.response.filename.endswith(".csv")
 
-        try:
-            response = subset(
+        with pytest.raises(WrongFormatRequested):
+            self.response = subset(
                 dataset_id="cmems_obs-sst_glo_phy_l3s_pir_P1D-m",
                 start_datetime="2023-11-01T00:00:00",
                 file_format="parquet",
                 dry_run=True,
             )
-            assert False
-        except WrongFormatRequested:
-            pass
 
     def flatten_request_dict(
         self, request_dict: dict[str, Optional[Union[str, Path]]]

--- a/tests/test_warnings_subset_bounds.py
+++ b/tests/test_warnings_subset_bounds.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 from json import loads
 
+import pytest
+
 from copernicusmarine import CoordinatesOutOfDatasetBounds, subset
 from tests.test_utils import execute_in_terminal
 
@@ -220,16 +222,17 @@ class TestWarningsSubsetBounds:
         assert int(elevation_coordinates_extent["minimum"]) == -47
         assert int(elevation_coordinates_extent["maximum"]) == 0
 
-    def test_error_coordinates_out_of_dataset_bounds(self):
-        try:
+    def test_error_coordinates_out_of_dataset_bounds(self, tmp_path):
+
+        with pytest.raises(CoordinatesOutOfDatasetBounds) as e:
             _ = subset(
                 dataset_id="cmems_mod_glo_phy_anfc_0.083deg_P1D-m",
                 start_datetime=datetime.today() + timedelta(10),
                 end_datetime=datetime.today()
                 + timedelta(days=10, hours=23, minutes=59),
+                output_directory=tmp_path,
             )
-        except CoordinatesOutOfDatasetBounds as e:
-            assert "Some of your subset selection" in e.__str__()
+        assert "Some of your subset selection" in e.__str__()
 
     def when_i_request_a_dataset_with_coordinates_selection_method_option(
         self, coordinates_selection_method


### PR DESCRIPTION
- The default value for `longitude_overlap` should be `False` otherwise we will never raise when the coordinates are out of bounds
- Changed the test `tests/test_warnings_subset_bounds.py::TestWarningsSubsetBounds::test_error_coordinates_out_of_dataset_bounds` because it was not properly testing it, as it was passing and downloading the data.
- Refactor some tests to use `with pytest.raises` instead of try except