### PR TITLE
fix: solve future warning from xarray

### DIFF
--- a/copernicusmarine/core_functions/custom_open_zarr.py
+++ b/copernicusmarine/core_functions/custom_open_zarr.py
@@ -33,8 +33,9 @@ def open_zarr(
         )
         return xarray.open_zarr(
             store,
-            **kwargs,
+            decode_times=True,
             decode_timedelta=True,
+            **kwargs,
         )
     else:
         from copernicusmarine.core_functions.custom_s3_store_zarr_v3 import (
@@ -51,7 +52,8 @@ def open_zarr(
         )
         return xarray.open_zarr(
             store,
-            **kwargs,
-            zarr_format=2,
+            decode_times=True,
             decode_timedelta=True,
+            zarr_format=2,
+            **kwargs,
         )

--- a/doc/changelog/v224.rst
+++ b/doc/changelog/v224.rst
@@ -14,6 +14,8 @@ New Features
 Fixes
 ^^^^^
 
+* Fixed a deprecation warning from `xarray <https://docs.xarray.dev/en/v2025.03.0/whats-new.html#id20>`_.
+
 
 Get
 ----


### PR DESCRIPTION
fix #398 

We now explicitly decode timedeltas (as it is now done implicitly) 

### Pull Request Checklist

Before merging this PR, ensure you have completed the following:

- [x] Requested code reviews
- [x] Added tests with adequate coverage
- [x] Updated relevant documentation
- [x] Updated the changelog
- [x] Updated end-of-life table (if applicable)

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--438.org.readthedocs.build/en/438/

<!-- readthedocs-preview copernicusmarine end -->