### PR TITLE
Update workflows that use macOS-13

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-22.04, macos-13, ubuntu-24.04]
+        os: [macos-latest, ubuntu-22.04, macos-14, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 
@@ -45,7 +45,7 @@ jobs:
       run: |
         if [ "${{ matrix.os }}" == "macos-latest" ]; then
           ARCH="macos-arm64"
-        elif [ "${{ matrix.os }}" == "macos-13" ]; then
+        elif [ "${{ matrix.os }}" == "macos-14" ]; then
           ARCH="macos-x86_64"
         elif [ "${{ matrix.os }}" == "ubuntu-22.04" ]; then
           ARCH="linux-glibc-2.35"

--- a/.github/workflows/binary-test.yml
+++ b/.github/workflows/binary-test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-22.04, macos-13, ubuntu-24.04]
+        os: [macos-latest, ubuntu-22.04, macos-14, ubuntu-24.04]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
 

--- a/.github/workflows/dependencies-tests.yml
+++ b/.github/workflows/dependencies-tests.yml
@@ -2,7 +2,7 @@ name: Dependencies tests
 
 on:
   schedule:
-    - cron: '0 0 * * 6'
+    - cron: "0 0 * * 6"
 
 jobs:
   test-dependencies-combinations:
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code

--- a/.github/workflows/tests_on_oss.yml
+++ b/.github/workflows/tests_on_oss.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13, windows-latest]
+        os: [macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     defaults:
@@ -30,7 +30,7 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v5
         with:
-            python-version: '3.13'
+          python-version: "3.13"
       - name: Install and configure Poetry
         uses: snok/install-poetry@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,8 @@ run-using-pyinstaller-macos:
 	pip install -e .
 	python -m PyInstaller --hiddenimport deprecated --noconfirm --clean --onefile --copy-metadata xarray --name copernicusmarine_macos-${ARCH}.cli  --copy-metada pandas --collect-data dask --collect-data distributed --collect-data tzdata --copy-metadata copernicusmarine copernicusmarine/command_line_interface/copernicus_marine.py --target-architecture=${ARCH} --copy-metadata zarr
 
-run-using-pyinstaller-macos-13: ARCH = x86_64
-run-using-pyinstaller-macos-13: run-using-pyinstaller-macos
+run-using-pyinstaller-macos-14: ARCH = x86_64
+run-using-pyinstaller-macos-14: run-using-pyinstaller-macos
 
 run-using-pyinstaller-macos-latest: ARCH = arm64
 run-using-pyinstaller-macos-latest: run-using-pyinstaller-macos


### PR DESCRIPTION
Jobs failed here: https://github.com/mercator-ocean/copernicus-marine-toolbox/actions/runs/19270087997/job/55095799606?pr=442

And this pointed out to: https://github.com/actions/runner-images/issues/13046

According to the information, then, we update the machines to use macOS-14 (see that 'latest' is already using macOS-15 and that changed since we did it).



### Pull Request Checklist

Before merging this PR, ensure you have completed the following:

- [x] Requested code reviews
- [ ] Added tests with adequate coverage
- [ ] Updated relevant documentation
- [ ] Updated the changelog
- [ ] Updated end-of-life table (if applicable)

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--443.org.readthedocs.build/en/443/

<!-- readthedocs-preview copernicusmarine end -->