### PR TITLE
fix: windows compatible file names and more time precise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,3 +141,4 @@ update-tests-snapshots:
 	pytest --snapshot-update tests/test_query_builder.py::TestQueryBuilder::test_return_available_fields
 	pytest --snapshot-update tests/test_request_files.py::TestRequestFiles::test_subset_request_with_request_file
 	pytest --snapshot-update tests/test_cf_compliance.py
+	pytest --snapshot-update tests/test_subset_split_on.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -2287,6 +2287,22 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
 
 [[package]]
+name = "pandas-stubs"
+version = "2.0.3.230814"
+description = "Type annotations for pandas"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pandas_stubs-2.0.3.230814-py3-none-any.whl", hash = "sha256:4b3dfc027d49779176b7daa031a3405f7b839bcb6e312f4b9f29fea5feec5b4f"},
+    {file = "pandas_stubs-2.0.3.230814.tar.gz", hash = "sha256:1d5cc09e36e3d9f9a1ed9dceae4e03eeb26d1b898dd769996925f784365c8769"},
+]
+
+[package.dependencies]
+numpy = {version = ">=1.25.0", markers = "python_version >= \"3.9\""}
+types-pytz = ">=2022.1.1"
+
+[[package]]
 name = "parso"
 version = "0.8.5"
 description = "A Python Parser"
@@ -3948,6 +3964,18 @@ files = [
 ]
 
 [[package]]
+name = "types-pytz"
+version = "2025.2.0.20251108"
+description = "Typing stubs for pytz"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "types_pytz-2025.2.0.20251108-py3-none-any.whl", hash = "sha256:0f1c9792cab4eb0e46c52f8845c8f77cf1e313cb3d68bf826aa867fe4717d91c"},
+    {file = "types_pytz-2025.2.0.20251108.tar.gz", hash = "sha256:fca87917836ae843f07129567b74c1929f1870610681b4c92cb86a3df5817bdb"},
+]
+
+[[package]]
 name = "types-requests"
 version = "2.31.0.6"
 description = "Typing stubs for requests"
@@ -4311,4 +4339,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "0d73947506606fea22646986684e26e7b9b493b4e2d1f84313c00ab0940a1900"
+content-hash = "3e59e867beab90c74a5b379cbeb0ecb0a48026547e6f189d89bbf976b316418e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ compliance-checker = { version = "^5.1.1", python = ">3.10, <3.14", markers = "s
 pytest-cov = "^6.1.1"
 responses = "^0.25.7"
 pytest = "^8.4.2"
+pandas-stubs = "2.0.3.230814"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/__snapshots__/test_subset_split_on.ambr
+++ b/tests/__snapshots__/test_subset_split_on.ambr
@@ -1,0 +1,34 @@
+# serializer version: 1
+# name: TestSubsetSplitOn.test_split_on_day
+  '''
+  [
+    "cmems_mod_glo_phy_anfc_0.083deg_P1D-m_ist-mlotst-pbo-siage-sialb-siconc-sisnthick-sithick-sivelo-sob-tob-usi-vsi-zos_1.00W-0.00E_49.00N-50.00N_2024-01-01T00-00-00.nc",
+    "cmems_mod_glo_phy_anfc_0.083deg_P1D-m_ist-mlotst-pbo-siage-sialb-siconc-sisnthick-sithick-sivelo-sob-tob-usi-vsi-zos_1.00W-0.00E_49.00N-50.00N_2024-01-02T00-00-00.nc",
+    "cmems_mod_glo_phy_anfc_0.083deg_P1D-m_ist-mlotst-pbo-siage-sialb-siconc-sisnthick-sithick-sivelo-sob-tob-usi-vsi-zos_1.00W-0.00E_49.00N-50.00N_2024-01-03T00-00-00.nc",
+    "cmems_mod_glo_phy_anfc_0.083deg_P1D-m_ist-mlotst-pbo-siage-sialb-siconc-sisnthick-sithick-sivelo-sob-tob-usi-vsi-zos_1.00W-0.00E_49.00N-50.00N_2024-01-04T00-00-00.nc",
+    "cmems_mod_glo_phy_anfc_0.083deg_P1D-m_ist-mlotst-pbo-siage-sialb-siconc-sisnthick-sithick-sivelo-sob-tob-usi-vsi-zos_1.00W-0.00E_49.00N-50.00N_2024-01-05T00-00-00.nc"
+  ]
+  '''
+# ---
+# name: TestSubsetSplitOn.test_split_on_day_monthly_dataset
+  '''
+  [
+    "cmems_mod_nws_bgc-chl_my_7km-3D_P1M-m_chl_10.00W-0.00E_45.00N-50.00N_0.00-100.00m_2022-01-01T00-00-00.nc",
+    "cmems_mod_nws_bgc-chl_my_7km-3D_P1M-m_chl_10.00W-0.00E_45.00N-50.00N_0.00-100.00m_2022-02-01T00-00-00.nc",
+    "cmems_mod_nws_bgc-chl_my_7km-3D_P1M-m_chl_10.00W-0.00E_45.00N-50.00N_0.00-100.00m_2022-03-01T00-00-00.nc",
+    "cmems_mod_nws_bgc-chl_my_7km-3D_P1M-m_chl_10.00W-0.00E_45.00N-50.00N_0.00-100.00m_2022-04-01T00-00-00.nc"
+  ]
+  '''
+# ---
+# name: TestSubsetSplitOn.test_split_on_hour
+  '''
+  [
+    "cmems_mod_glo_phy_anfc_0.083deg_PT1H-m_so-thetao-uo-vo-zos_1.00W-0.00E_49.00N-50.00N_0.00-1.00m_2024-01-01T00-00-00.nc",
+    "cmems_mod_glo_phy_anfc_0.083deg_PT1H-m_so-thetao-uo-vo-zos_1.00W-0.00E_49.00N-50.00N_0.00-1.00m_2024-01-01T01-00-00.nc",
+    "cmems_mod_glo_phy_anfc_0.083deg_PT1H-m_so-thetao-uo-vo-zos_1.00W-0.00E_49.00N-50.00N_0.00-1.00m_2024-01-01T02-00-00.nc",
+    "cmems_mod_glo_phy_anfc_0.083deg_PT1H-m_so-thetao-uo-vo-zos_1.00W-0.00E_49.00N-50.00N_0.00-1.00m_2024-01-01T03-00-00.nc",
+    "cmems_mod_glo_phy_anfc_0.083deg_PT1H-m_so-thetao-uo-vo-zos_1.00W-0.00E_49.00N-50.00N_0.00-1.00m_2024-01-01T04-00-00.nc",
+    "cmems_mod_glo_phy_anfc_0.083deg_PT1H-m_so-thetao-uo-vo-zos_1.00W-0.00E_49.00N-50.00N_0.00-1.00m_2024-01-01T05-00-00.nc"
+  ]
+  '''
+# ---

--- a/tests/test_subset_split_on.py
+++ b/tests/test_subset_split_on.py
@@ -131,18 +131,18 @@ class TestSubsetSplitOn:
         assert os.path.exists(
             os.path.join(
                 tmp_path,
-                "cmems_mod_glo_phy-all_my_0.25deg_P1D-m_siconc_glor_9.90W-9.50W_33.90N-35.00N_5.00-6.00m_2022-01-01-2022-02-10.nc",
+                "cmems_mod_glo_phy-all_my_0.25deg_P1D-m_siconc_glor_9.90W-9.50W_33.90N-35.00N_5.00-6.00m_2022-01-01T00-00-00-2022-02-10T00-00-00.nc",
             )
         )
         assert os.path.exists(
             os.path.join(
                 tmp_path,
-                "cmems_mod_glo_phy-all_my_0.25deg_P1D-m_thetao_cglo_9.90W-9.50W_33.90N-35.00N_5.00-6.00m_2022-01-01-2022-02-10.nc",
+                "cmems_mod_glo_phy-all_my_0.25deg_P1D-m_thetao_cglo_9.90W-9.50W_33.90N-35.00N_5.00-6.00m_2022-01-01T00-00-00-2022-02-10T00-00-00.nc",
             )
         )
         path_vo_cglo = os.path.join(
             tmp_path,
-            "cmems_mod_glo_phy-all_my_0.25deg_P1D-m_vo_cglo_9.90W-9.50W_33.90N-35.00N_5.00-6.00m_2022-01-01-2022-02-10.nc",
+            "cmems_mod_glo_phy-all_my_0.25deg_P1D-m_vo_cglo_9.90W-9.50W_33.90N-35.00N_5.00-6.00m_2022-01-01T00-00-00-2022-02-10T00-00-00.nc",
         )
         assert os.path.exists(path_vo_cglo)
         ds_vo_cglo = xarray.open_dataset(path_vo_cglo)
@@ -158,7 +158,7 @@ class TestSubsetSplitOn:
         assert "vo_cglo" in ds_vo_cglo.data_vars
         ds_vo_cglo.close()
 
-    def test_split_on_day_monthly_dataset(self, tmp_path):
+    def test_split_on_day_monthly_dataset(self, tmp_path, snapshot):
         res = subset_split_on(
             dataset_id="cmems_mod_nws_bgc-chl_my_7km-3D_P1M-m",
             start_datetime="2022-01-01",
@@ -175,27 +175,9 @@ class TestSubsetSplitOn:
         )
         assert len(res) == 4
         filenames = [f.filename for f in res]
-        assert (
-            "cmems_mod_nws_bgc-chl_my_7km-3D_P1M-m_chl_10.00W-0.00E_45.00N-50.00N_0.00-100.00m_2022-01-01.nc"
-            in filenames
-        )
+        assert snapshot == json.dumps(filenames, indent=2)
 
-        assert (
-            "cmems_mod_nws_bgc-chl_my_7km-3D_P1M-m_chl_10.00W-0.00E_45.00N-50.00N_0.00-100.00m_2022-02-01.nc"
-            in filenames
-        )
-
-        assert (
-            "cmems_mod_nws_bgc-chl_my_7km-3D_P1M-m_chl_10.00W-0.00E_45.00N-50.00N_0.00-100.00m_2022-03-01.nc"
-            in filenames
-        )
-
-        assert (
-            "cmems_mod_nws_bgc-chl_my_7km-3D_P1M-m_chl_10.00W-0.00E_45.00N-50.00N_0.00-100.00m_2022-04-01.nc"
-            in filenames
-        )
-
-    def test_split_on_day(self, tmp_path):
+    def test_split_on_day(self, tmp_path, snapshot):
         res = subset_split_on(
             dataset_id="cmems_mod_glo_phy_anfc_0.083deg_P1D-m",
             start_datetime="2024-01-01",
@@ -212,12 +194,9 @@ class TestSubsetSplitOn:
         )
         assert len(res) == 5
         filenames = [f.filename for f in res]
-        assert (
-            "cmems_mod_glo_phy_anfc_0.083deg_P1D-m_ist-mlotst-pbo-siage-sialb-siconc-sisnthick-sithick-sivelo-sob-tob-usi-vsi-zos_1.00W-0.00E_49.00N-50.00N_2024-01-01.nc"
-            in filenames
-        )
+        assert snapshot == json.dumps(filenames, indent=2)
 
-    def test_split_on_hour(self, tmp_path):
+    def test_split_on_hour(self, tmp_path, snapshot):
         res = subset_split_on(
             dataset_id="cmems_mod_glo_phy_anfc_0.083deg_PT1H-m",
             start_datetime="2024-01-01T00:00:00",
@@ -234,10 +213,7 @@ class TestSubsetSplitOn:
         )
         assert len(res) == 6
         filenames = [f.filename for f in res]
-        assert (
-            "cmems_mod_glo_phy_anfc_0.083deg_PT1H-m_so-thetao-uo-vo-zos_1.00W-0.00E_49.00N-50.00N_0.00-1.00m_2024-01-01T00:00:00.nc"
-            in filenames
-        )
+        assert snapshot == json.dumps(filenames, indent=2)
 
     def test_split_on_cli(self):
         command = [


### PR DESCRIPTION
fix [CMT-347](https://cms-change.atlassian.net/browse/CMT-347)
fix [CMT-359](https://cms-change.atlassian.net/browse/CMT-359)

Fixes two issues (on the same PR as they touch the same part of the code):

- `:` are not valid for Windows filenames, we use now `"%Y-%m-%dT%H-%M-%S"`
- Timestamps on name for results of split-on where not precise before, they are now always precise at the second (`"%Y-%m-%dT%H-%M-%S"`)

Also added snapshots to the split-on tests for comfort. 

[CMT-347]: https://cms-change.atlassian.net/browse/CMT-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CMT-359]: https://cms-change.atlassian.net/browse/CMT-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Pull Request Checklist

Before merging this PR, ensure you have completed the following:

- [ ] Requested code reviews
- [ ] Added tests with adequate coverage
- [ ] Updated relevant documentation
- [ ] Updated the changelog
- [ ] Updated end-of-life table (if applicable)