### PR TITLE
only prompt once when a credentials file with wrong credentials exists

### DIFF
--- a/copernicusmarine/core_functions/login.py
+++ b/copernicusmarine/core_functions/login.py
@@ -46,7 +46,7 @@ def login_function(
             username=username,
             password=password,
             configuration_file_directory=configuration_file_directory,
-            force_overwrite=force_overwrite,
+            force_overwrite=overwrite,
         )
         if has_been_aborted:
             logger.info("No configuration file have been modified.")


### PR DESCRIPTION


<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--489.org.readthedocs.build/en/489/

<!-- readthedocs-preview copernicusmarine end -->