### PR TITLE
fix: increase safety on GHA

### DIFF
--- a/.github/workflows/binary-test-windows.yml
+++ b/.github/workflows/binary-test-windows.yml
@@ -7,7 +7,7 @@ on:
       - "main"
       - "release/**"
       - "pre-release/**"
-  pull_request_target:
+  pull_request:
     branches:
       - "main"
     paths:
@@ -22,7 +22,6 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
     - uses: mamba-org/setup-micromamba@v1

--- a/.github/workflows/binary-test.yml
+++ b/.github/workflows/binary-test.yml
@@ -7,7 +7,7 @@ on:
       - "main"
       - "release/**"
       - "pre-release/**"
-  pull_request_target:
+  pull_request:
     branches:
       - "main"
     paths:
@@ -29,7 +29,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - uses: mamba-org/setup-micromamba@v1

--- a/.github/workflows/link-PR-doc.yml
+++ b/.github/workflows/link-PR-doc.yml
@@ -1,6 +1,6 @@
 name: readthedocs/actions
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,7 @@
 name: Run tests
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "main"
       - "release/**"
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5

--- a/.github/workflows/tests_on_oss.yml
+++ b/.github/workflows/tests_on_oss.yml
@@ -1,7 +1,7 @@
 name: Run tests OSs
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "main"
       - "release/**"
@@ -24,8 +24,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up python
         id: setup-python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Seems like there is more and more attacks on public repos to get Secrets from github actions, especially because of `pull_request_target`

### Pull Request Checklist

Before merging this PR, ensure you have completed the following:

- [x] Requested code reviews
- [x] Added tests with adequate coverage
- [x] Updated relevant documentation
- [x] Updated the changelog
- [x] Updated end-of-life table (if applicable)

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--491.org.readthedocs.build/en/491/

<!-- readthedocs-preview copernicusmarine end -->