### PR TITLE
fix: check type in metadata to get time axis

### DIFF
--- a/copernicusmarine/catalogue_parser/models.py
+++ b/copernicusmarine/catalogue_parser/models.py
@@ -149,7 +149,7 @@ class CopernicusMarineCoordinate(BaseModel):
     #: Chunk geometric factor of the coordinate.
     chunk_geometric_factor: float | int | None
     #: Axis of the coordinate
-    axis: Literal["x", "y", "z", "t"]
+    axis: Literal["x", "y", "z", "t"] | None
 
     @classmethod
     def from_metadata_item(
@@ -184,7 +184,9 @@ class CopernicusMarineCoordinate(BaseModel):
                     arco_data_metadata_producer_valid_start_index:
                 ]
         chunking_length = dimension_metadata.get("chunkLen")
-        axis = cube_dimensions[dimension].get("axis", "t")
+        axis = cube_dimensions[dimension].get("axis")
+        if not axis and cube_dimensions[dimension].get("type") == "temporal":
+            axis = "t"
         if isinstance(chunking_length, dict):
             chunking_length = chunking_length.get(variable_id)
 
@@ -401,6 +403,8 @@ class CopernicusMarineService(BaseModel):
         axis_coordinate_id_mapping: dict[str, str] = {}
         for variable in self.variables:
             for coordinate in variable.coordinates:
+                if not coordinate.axis:
+                    continue
                 if len(axis_coordinate_id_mapping) == 4:
                     return axis_coordinate_id_mapping
                 axis_coordinate_id_mapping[

--- a/copernicusmarine/download_functions/subset_xarray.py
+++ b/copernicusmarine/download_functions/subset_xarray.py
@@ -312,7 +312,7 @@ def _x_axis_subset(
     longitude_parameters: XParameters,
     coordinates_selection_method: CoordinatesSelectionMethod,
 ) -> xarray.Dataset:
-    (x_selection, shift_window) = x_axis_selection(longitude_parameters)
+    x_selection, shift_window = x_axis_selection(longitude_parameters)
     if shift_window and isinstance(x_selection, slice):
         dataset = _shift_longitude_dimension(
             dataset,

--- a/tests/test_subset.py
+++ b/tests/test_subset.py
@@ -1849,3 +1849,20 @@ class TestSubset:
             )
             assert "WARNING" in caplog.text
             assert 'Selected dataset version: "202511"' in caplog.text
+
+    def test_subset_with_additional_dimensions(self, tmp_path):
+        # climatology dataset has an nv dimension.
+        # we shouldn't consider it in the subset axes
+        response = subset(
+            dataset_id="cmems_mod_bal_wav_my_2km-climatology_P1M-m",
+            start_datetime="2001",
+            dry_run=True,
+            output_directory=tmp_path,
+        )
+
+        assert "time" in [
+            coor.coordinate_id for coor in response.coordinates_extent
+        ]
+        assert "nv" not in [
+            coor.coordinate_id for coor in response.coordinates_extent
+        ]


### PR DESCRIPTION
fix an issue where the climatology datasets couldn't be subsetted due to the introduction of a new dimension
fix [CMT-396](https://cms-change.atlassian.net/browse/CMT-396)

### Pull Request Checklist

Before merging this PR, ensure you have completed the following:

- [ ] Requested code reviews
- [ ] Added tests with adequate coverage
- [ ] Updated relevant documentation
- [ ] Updated the changelog
- [ ] Updated end-of-life table (if applicable)

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--502.org.readthedocs.build/en/502/

<!-- readthedocs-preview copernicusmarine end -->

[CMT-396]: https://cms-change.atlassian.net/browse/CMT-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ