### PR TITLE
fix: dataset version can also be used with the describe

### DIFF
--- a/copernicusmarine/core_functions/describe.py
+++ b/copernicusmarine/core_functions/describe.py
@@ -76,7 +76,7 @@ def describe_function(
     return response_catalogue
 
 
-def _parse_dataset_id_and_version(dataset_id: str):
+def _parse_dataset_id_and_version(dataset_id: str) -> str:
     dataset_id_without_version, dataset_version = get_version_from_dataset_id(
         dataset_id=dataset_id, raise_on_error=False
     )
@@ -84,8 +84,7 @@ def _parse_dataset_id_and_version(dataset_id: str):
         logger.warning(
             "The dataset version has been included "
             "in the dataset_id argument. "
-            "This is not recommended. "
-            "The describe command will return all"
-            "the available versions of the dataset."
+            "This is not recommended: "
+            "the version suffix will be ignored. "
         )
     return dataset_id_without_version

--- a/copernicusmarine/core_functions/describe.py
+++ b/copernicusmarine/core_functions/describe.py
@@ -9,6 +9,7 @@ from copernicusmarine.catalogue_parser.models import (
     CopernicusMarineCatalogue,
     DatasetNotFound,
     ProductNotFound,
+    get_version_from_dataset_id,
 )
 from copernicusmarine.core_functions.marine_datastore_config import (
     get_config_and_check_version_describe,
@@ -34,6 +35,9 @@ def describe_function(
             "Data will come from the staging environment."
         )
     catalogues: list[CopernicusMarineCatalogue] = []
+
+    if force_dataset_id:
+        force_dataset_id = _parse_dataset_id_and_version(force_dataset_id)
     for i, catalogue_config in enumerate(marine_datasetore_config.catalogues):
         try:
             catalogue: CopernicusMarineCatalogue | None = parse_catalogue(
@@ -70,3 +74,18 @@ def describe_function(
         else base_catalogue
     )
     return response_catalogue
+
+
+def _parse_dataset_id_and_version(dataset_id: str):
+    dataset_id_without_version, dataset_version = get_version_from_dataset_id(
+        dataset_id=dataset_id, raise_on_error=False
+    )
+    if dataset_version:
+        logger.warning(
+            "The dataset version has been included "
+            "in the dataset_id argument. "
+            "This is not recommended. "
+            "The describe command will return all"
+            "the available versions of the dataset."
+        )
+    return dataset_id_without_version

--- a/doc/changelog/v250.rst
+++ b/doc/changelog/v250.rst
@@ -10,4 +10,4 @@ Fixes
 ^^^^^
 
 * Fixed an issue where the ``describe`` command would fail when the same datasetID would be present in multiple products.
-* Fixed an issue where adding the version of the dataset in the datasetID would not work at all. Now, it correctly parses the input and logs a warning if needed.
+* Fixed an issue where adding the version of the dataset in the datasetID would not work. Now, it correctly parses the input and logs a warning.

--- a/doc/changelog/v250.rst
+++ b/doc/changelog/v250.rst
@@ -10,3 +10,4 @@ Fixes
 ^^^^^
 
 * Fixed an issue where the ``describe`` command would fail when the same datasetID would be present in multiple products.
+* Fixed an issue where adding the version of the dataset in the datasetID would not work at all. Now, it correctly parses the input and logs a warning if needed.

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -657,3 +657,12 @@ class TestDescribe:
         assert len(describe_result.products) == 2
         get_result = get(dataset_id=dataset_id, dry_run=True)
         assert get_result is not None
+
+    def test_describe_dataset_id_with_version(self, caplog):
+        with caplog.at_level(logging.INFO, logger="copernicusmarine"):
+            result = describe(
+                dataset_id="cmems_mod_glo_phy_my_0.083deg_P1M-m_202311"
+            )
+            assert result
+            assert "WARNING" in caplog.text
+            assert "The dataset version has been included" in caplog.text


### PR DESCRIPTION
Fix an issue where adding the version to a dataset wouldn't work with the describe, and the dataset wouldn't be found

fix [CMT-399](https://cms-change.atlassian.net/browse/CMT-399)

[CMT-399]: https://cms-change.atlassian.net/browse/CMT-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Pull Request Checklist

Before merging this PR, ensure you have completed the following:

- [x] Requested code reviews
- [x] Added tests with adequate coverage
- [x] Updated relevant documentation
- [x] Updated the changelog
- [x] Updated end-of-life table (if applicable)