### PR TITLE
feat: login compatible with pyodide for my ocean

### DIFF
--- a/copernicusmarine/core_functions/credentials_utils.py
+++ b/copernicusmarine/core_functions/credentials_utils.py
@@ -1,6 +1,7 @@
 import base64
 import configparser
 import logging
+import os
 import pathlib
 from netrc import netrc
 from platform import system
@@ -528,10 +529,14 @@ def get_and_check_username_password(
     username: str | None,
     password: str | None,
     credentials_file: pathlib.Path | None,
-) -> tuple[str, str]:
+) -> str:
     username, password = get_username_password(
         username=username, password=password, credentials_file=credentials_file
     )
+    if token := os.getenv("COPERNICUSMARINE_MYOCEAN_AUTH"):
+        if not (user_myocean := check_credentials_from_myocean_bearer(token)):
+            raise InvalidUsernameOrPassword("Invalid MyOcean token.")
+        return user_myocean
     user = _validate_and_get_user(
         username,
         password,
@@ -542,7 +547,20 @@ def get_and_check_username_password(
             "https://help.marine.copernicus.eu/en/articles/"
             "4444552-i-forgot-my-username-or-my-password-what-should-i-do"
         )
-    return (user, password)
+    return user
+
+
+def check_credentials_from_myocean_bearer(token: str) -> str:
+    MYOCEAN_AUTH_URL = "https://data-be-prd.marine.copernicus.eu/api/user"
+    session = get_configured_requests_session()
+    bearer_auth = BearerAuth(token)
+    response = session.get(
+        MYOCEAN_AUTH_URL,
+        auth=bearer_auth,
+    )
+    session.close()
+    username = response.json().get("username")
+    return username
 
 
 def get_username_password(

--- a/copernicusmarine/core_functions/request_structure.py
+++ b/copernicusmarine/core_functions/request_structure.py
@@ -318,7 +318,7 @@ def create_subset_request(
         if "credentials_file" in json_content and not credentials_file:
             credentials_file = pathlib.Path(json_content["credentials_file"])
 
-    username, _ = get_and_check_username_password(
+    username = get_and_check_username_password(
         username,
         password,
         credentials_file,
@@ -666,7 +666,7 @@ def create_get_request(
         if "credentials_file" in json_content and not credentials_file:
             credentials_file = pathlib.Path(json_content["credentials_file"])
 
-    username, _ = get_and_check_username_password(
+    username = get_and_check_username_password(
         username, password, credentials_file
     )
     get_request = GetRequest(dataset_id=dataset_id or "", username=username)


### PR DESCRIPTION
A way to pass a bearer directly that would allow using pyodide directly from MyOcean

fix [CMT-406](https://cms-change.atlassian.net/browse/CMT-406)

### Pull Request Checklist

Before merging this PR, ensure you have completed the following:

- [ ] Requested code reviews
- [ ] Added tests with adequate coverage
- [ ] Updated relevant documentation
- [ ] Updated the changelog
- [ ] Updated end-of-life table (if applicable)

<!-- readthedocs-preview copernicusmarine start -->
----
📚 Documentation preview 📚: https://copernicusmarine--517.org.readthedocs.build/en/517/

<!-- readthedocs-preview copernicusmarine end -->

[CMT-406]: https://cms-change.atlassian.net/browse/CMT-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ