### PR TITLE
fix: no warning for the binaries

### DIFF
--- a/copernicusmarine/command_line_interface/copernicus_marine.py
+++ b/copernicusmarine/command_line_interface/copernicus_marine.py
@@ -1,4 +1,13 @@
 import multiprocessing
+import warnings
+
+# Silence the pkg_resources deprecation warning emitted by bundled
+# dependencies (e.g. dask/distributed) when running the PyInstaller binary.
+warnings.filterwarnings(
+    "ignore",
+    message="pkg_resources is deprecated as an API.*",
+    category=UserWarning,
+)
 
 multiprocessing.freeze_support()
 

--- a/doc/changelog/v250.rst
+++ b/doc/changelog/v250.rst
@@ -14,6 +14,11 @@ New Features
   * ``geopandas`` (>=1.1.4)
   * ``netcdf4`` (<=1.7.2, not available on Windows)
 
+Fixes
+^^^^^
+
+* Fixed the ``pkg_resources is deprecated`` warning emitted by the standalone binaries when running any command.
+
 
 Describe
 --------

--- a/tests_extra/test_basic_commands_binaries.py
+++ b/tests_extra/test_basic_commands_binaries.py
@@ -33,6 +33,16 @@ class TestBasicCommandsBinaries:
         self.output = execute_in_terminal(command, shell=False)
         assert self.output.returncode == 0
 
+    def test_no_pkg_resources_deprecation_warning(self):
+        command = [
+            BINARY,
+            "describe",
+        ]
+        self.output = execute_in_terminal(command, shell=False)
+        assert self.output.returncode == 0
+        assert "pkg_resources is deprecated" not in self.output.stderr
+        assert "pkg_resources is deprecated" not in self.output.stdout
+
     def test_subset(self):
         command = [
             BINARY,


### PR DESCRIPTION
No warning for the binaries
fix [CMT-375](https://cms-change.atlassian.net/browse/CMT-375)

Just suppresses the warning, as it is a dependency we don't import; it probably comes from dask 

### Pull Request Checklist

Before merging this PR, ensure you have completed the following:

- [ ] Requested code reviews
- [ ] Added tests with adequate coverage
- [ ] Updated relevant documentation
- [ ] Updated the changelog
- [ ] Updated end-of-life table (if applicable)

[CMT-375]: https://cms-change.atlassian.net/browse/CMT-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ